### PR TITLE
Improve startup and conflict verbiage

### DIFF
--- a/Version Control.accda.src/forms/frmVCSConflict.bas
+++ b/Version Control.accda.src/forms/frmVCSConflict.bas
@@ -830,7 +830,6 @@ Attribute VB_Exposed = False
 Option Compare Database
 Option Explicit
 
-
 '---------------------------------------------------------------------------------------
 ' Procedure : cmdCancel_Click
 ' Author    : Adam Waller
@@ -876,15 +875,25 @@ End Sub
 '---------------------------------------------------------------------------------------
 '
 Private Sub Form_Load()
-
     ' Display version (better performance than bound control)
     lblVersion.Caption = Replace(lblVersion.Caption, "${version}", GetVCSVersion())
     
+    Dim frmList As Form_frmVCSConflictList
+    Set frmList = Me.sfrmConflictList.Form
+        
     ' Update heading caption
     If Log.OperationType = eotExport Then
         lblHeading.Caption = "These source files have changed since the last export"
+        With frmList.cboResolution
+            .AddItem eResolveConflict.ercSkip & ";" & "Skip"
+            .AddItem eResolveConflict.ercOverwrite & ";" & "Overwrite source file"
+        End With
     Else
         lblHeading.Caption = "These database objects have changed since the last export"
+        With frmList.cboResolution
+            .AddItem eResolveConflict.ercSkip & ";" & "Skip"
+            .AddItem eResolveConflict.ercOverwrite & ";" & "Overwrite database object"
+        End With
     End If
     
 End Sub

--- a/Version Control.accda.src/forms/frmVCSConflictList.bas
+++ b/Version Control.accda.src/forms/frmVCSConflictList.bas
@@ -25,7 +25,6 @@ Begin Form
     End
     RecordSource ="tblConflicts"
     DatasheetFontName ="Calibri"
-    OnLoad ="[Event Procedure]"
     AllowFormView =0
     FilterOnLoad =0
     ShowPageMargins =0
@@ -461,22 +460,6 @@ Attribute VB_PredeclaredId = True
 Attribute VB_Exposed = False
 Option Compare Database
 Option Explicit
-
-
-'---------------------------------------------------------------------------------------
-' Procedure : Form_Load
-' Author    : Adam Waller
-' Date      : 5/27/2021
-' Purpose   : Load list of conflict resolutions
-'---------------------------------------------------------------------------------------
-'
-Private Sub Form_Load()
-    With cboResolution
-        .AddItem eResolveConflict.ercSkip & ";" & "Skip"
-        .AddItem eResolveConflict.ercOverwrite & ";" & "Overwrite"
-    End With
-End Sub
-
 
 '---------------------------------------------------------------------------------------
 ' Procedure : txtDiff_Click

--- a/Version Control.accda.src/macros/autoexec.bas
+++ b/Version Control.accda.src/macros/autoexec.bas
@@ -1,17 +1,57 @@
 ﻿Version =196611
 ColumnsShown =0
 Begin
+    Action ="SetLocalVar"
+    Argument ="__*L0_"
+    Argument ="[CurrentProject].[IsTrusted]"
+End
+Begin
+    Action ="SetLocalVar"
+    Argument ="__*L0C_"
+    Argument ="[LocalVars]![__*L0_]"
+End
+Begin
+    Condition ="[LocalVars]![__*L0C_]"
     Action ="RunCode"
     Argument ="AutoRun()"
 End
 Begin
-    Comment ="_AXL:<?xml version=\"1.0\" encoding=\"UTF-16\" standalone=\"no\"?>\015\012<UserI"
-        "nterfaceMacro MinimumClientDesignVersion=\"14.0.0000.0000\" xmlns=\"http://schem"
-        "as.microsoft.com/office/accessservices/2009/11/application\" xmlns:a=\"http://sc"
-        "hemas.microsoft.com/office/acc"
+    Action ="SetLocalVar"
+    Argument ="__*L0C_"
+    Argument ="(Not [LocalVars]![__*L0_])"
 End
 Begin
-    Comment ="_AXL:essservices/2009/11/forms\"><Statements><Action Name=\"RunCode\"><Argument "
-        "Name=\"FunctionName\">AutoRun()</Argument></Action></Statements></UserInterfaceM"
-        "acro>"
+    Condition ="[LocalVars]![__*L0C_]"
+    Action ="MsgBox"
+    Argument ="The add-In is not trusted currently. Please click \"Enable Contents\" to trust t"
+        "he add-in and thus execute the startup code normally."
+    Argument ="-1"
+    Argument ="2"
+    Argument ="Add-in is not trusted"
+End
+Begin
+    Action ="SetLocalVar"
+    Argument ="__*L0C_"
+    Argument ="False"
+End
+Begin
+    Comment ="_AXL:<?xml version=\"1.0\" encoding=\"UTF-16\" standalone=\"no\"?>\015\012<UserI"
+        "nterfaceMacro MinimumClientDesignVersion=\"14.0.0000.0000\" xmlns=\"http://schem"
+        "as.microsoft.com/office/accessservices/2009/11/application\"><Statements><Condit"
+        "ionalBlock><If><Condition>[Cu"
+End
+Begin
+    Comment ="_AXL:rrentProject].[IsTrusted]</Condition><Statements><Action Name=\"RunCode\"><"
+        "Argument Name=\"FunctionName\">AutoRun()</Argument></Action></Statements></If><E"
+        "lse><Statements><Action Name=\"MessageBox\"><Argument Name=\"Message\">The add-I"
+        "n is not trusted curr"
+End
+Begin
+    Comment ="_AXL:ently. Please click \"Enable Contents\" to trust the add-in and thus execut"
+        "e the startup code normally.</Argument><Argument Name=\"Type\">Warning?</Argumen"
+        "t><Argument Name=\"Title\">Add-in is not trusted</Argument></Action></Statements"
+        "></Else></Condition"
+End
+Begin
+    Comment ="_AXL:alBlock></Statements></UserInterfaceMacro>"
 End


### PR DESCRIPTION
This small PR helps avoids an annoying macro error dialog from showing when running the file untrusted and improves the resolution verbiage to avoid ambiguity on the action being taken. 