### PR TITLE
Fix #418

### DIFF
--- a/Version Control.accda.src/dbs-properties.json
+++ b/Version Control.accda.src/dbs-properties.json
@@ -41,7 +41,7 @@
       "Type": 10
     },
     "AppVersion": {
-      "Value": "4.0.16",
+      "Value": "4.0.17",
       "Type": 10
     },
     "Auto Compact": {

--- a/Version Control.accda.src/modules/modFileWinAPI.bas
+++ b/Version Control.accda.src/modules/modFileWinAPI.bas
@@ -180,12 +180,12 @@ End Function
 '
 Public Sub SetFileDate(strFile As String, dteDate As Date, blnAsLocalTime As Boolean)
 
-    Dim lngHandle As Long
+    Dim lngHandle As LongPtr
     Dim stNewDate As SYSTEMTIME
     Dim stUtc As SYSTEMTIME
     Dim ftUtc As FILETIME
     Dim ftBlank As FILETIME
-    Dim lngResult As Long
+    Dim lngResult As LongPtr
     Dim strFullPath As String
 
     Perf.OperationStart "Set file modified date"
@@ -255,7 +255,7 @@ Public Function FileTimeToDate(tFileTime As FILETIME, blnAsLocalTime As Boolean)
 
     Dim tReturnTime As SYSTEMTIME
     Dim tUtcTime As SYSTEMTIME
-    Dim lngResult As Long
+    Dim lngResult As LongPtr
 
     ' Get UTC file time
     FileTimeToSystemTime tFileTime, tUtcTime


### PR DESCRIPTION
Fixes #418

If Office 32 versions can't use `longptr` we will need to use conditional compiling.