### PR TITLE
Fixes #427 and bump version number.

### DIFF
--- a/Version Control.accda.src/forms/frmVCSInstall.bas
+++ b/Version Control.accda.src/forms/frmVCSInstall.bas
@@ -1861,9 +1861,15 @@ Private Sub cmdChangeInstallFolder_Click()
 
     ' See if the add-in is already installed
     If FSO.FileExists(GetAddInFileName) Then
-        MsgBox2 "Please Uninstall First", _
-            "If you want to change the installation path, please uninstall the add-in, then reinstall to the desired location.", _
-            "(You will have the option to keep your current settings during the uninstall process.)", vbExclamation
+        MsgBox2 "Please Uninstall First" _
+            , "Please uninstall (and delete) the add-in, then reinstall to the new location. " & _
+            "If you have already uninstalled, delete the addin file. " & _
+            "The install folder will open now to allow you to delete the file." _
+            , "You will have the option to keep your current settings during the uninstall process." _
+            , vbExclamation
+
+        Application.FollowHyperlink GetInstallSettings.strInstallFolder
+
     Else
         ' Show a folder picker to select the desired location.
         ' (The path will be validated before installation, just in case it is changed direclty in the text box.)

--- a/Version Control.accda.src/vcs-options.json
+++ b/Version Control.accda.src/vcs-options.json
@@ -1,6 +1,6 @@
 ﻿{
   "Info": {
-    "AddinVersion": "4.0.19",
+    "AddinVersion": "4.0.20",
     "AccessVersion": "14.0 32-bit"
   },
   "Options": {


### PR DESCRIPTION
Fixes #427 

Basically updates the message box as to what needs to happen, and then opens the folder. 

The previous mechanism for detecting if it's installed was simply to see if the accde file was there or not. I didn't change any of that behavior, just updated the text and open folder.