### PR TITLE
Additional Optimizations for parsing time

### DIFF
--- a/Version Control.accda.src/dbs-properties.json
+++ b/Version Control.accda.src/dbs-properties.json
@@ -41,7 +41,7 @@
       "Type": 10
     },
     "AppVersion": {
-      "Value": "4.0.26",
+      "Value": "4.0.27",
       "Type": 10
     },
     "Auto Compact": {

--- a/Version Control.accda.src/modules/modUtcConverter.bas
+++ b/Version Control.accda.src/modules/modUtcConverter.bas
@@ -812,16 +812,16 @@ End Function
 ' Purpose   : Attempt a higher performance conversion first, then fall back to RegEx.
 '---------------------------------------------------------------------------------------
 '
-Private Function ConvTimeUTC(ByVal InVal As String) As Date
+Private Function ConvTimeUTC(ByRef InVal As String) As Date
 
     Dim varParts As Variant
-    Dim SecondsInPart As String
+    Dim InValSeconds As String
 
     If InVal Like "##:##:##.###Z" Then
         ' Use high-performance conversion to date
         varParts = Split(InVal, ":")
-        SecondsInPart = Mid(varParts(2), 1, Len(varParts(2)) - 1)
-        ConvTimeUTC = TimeSerialDbl(varParts(0), varParts(1), SecondsInPart)
+        InValSeconds = Mid(varParts(2), 1, Len(varParts(2)) - 1)
+        ConvTimeUTC = TimeSerialDbl(varParts(0), varParts(1), InValSeconds)
     Else
         ' Fall back to slower RegEx function
         ConvTimeUTC = ConvTimeUTC2(InVal)

--- a/Version Control.accda.src/modules/modUtcConverter.bas
+++ b/Version Control.accda.src/modules/modUtcConverter.bas
@@ -563,18 +563,38 @@ Public Function ConvertToISO8601Time(ByVal DateIn As Date _
     End If
 
     ConvertToISO8601Time = String_BufferToString(tString_Buffer)
+
 End Function
 
 
 ' Provides a format string to other functions that complies with ISO8601
-Private Function ISOTimeFormatStr(Optional IncludeMilliseconds As Boolean = False _
-                                , Optional includeTimeZone As Boolean = False) As String
-    Dim tString_Buffer As StringBufferCache
+Public Function ISOTimeFormatStr(Optional ByVal IncludeMilliseconds As Boolean = False _
+                                , Optional ByVal IncludeTimeZonePart As Boolean = False _
+                                , Optional ByVal IncludeLocalTimeZone As Boolean = False) As String
 
-    String_BufferAppend tString_Buffer, "yyyy-mm-ddTHH:mm:ss"
-    If IncludeMilliseconds Then String_BufferAppend tString_Buffer, ".000"
-    If includeTimeZone Then String_BufferAppend tString_Buffer, ISOTimezoneOffset
-    ISOTimeFormatStr = String_BufferToString(tString_Buffer)
+    Static f_dFormatString As Scripting.Dictionary
+
+    Dim DictPosition As Long
+
+    If f_dFormatString Is Nothing Then Set f_dFormatString = New Scripting.Dictionary
+
+    DictPosition = (4 And IncludeMilliseconds) + (2 And IncludeTimeZonePart) + (1 And IncludeLocalTimeZone)
+
+    If Not f_dFormatString.Exists(DictPosition) Then
+        With New clsConcat
+            .Add "yyyy-mm-ddTHH:mm:ss"
+            If IncludeMilliseconds Then .Add ".000"
+            If IncludeTimeZonePart And IncludeLocalTimeZone Then
+                .Add CurrentISOTimezoneOffset
+            ElseIf IncludeTimeZonePart Then
+                .Add ISO8601UTCTimeZone
+            End If
+            f_dFormatString.Add DictPosition, .GetStr
+        End With
+    End If
+
+    ISOTimeFormatStr = f_dFormatString.Item(DictPosition)
+
 End Function
 
 


### PR DESCRIPTION
While troubleshooting some of the performance issues in #454 and #354, I also discovered these functions could be further optimized for speed and still keep millisecond accuracy outputs are possible; this has been invaluable when troubleshooting race conditions in some of our applications (especially when using `TimeStampDate` and `ISO8601TimeStamp` for logging.

I've run this on my machine quite a few times and they're a bit faster as well. 

I also reverted back some of the name changes so the original function name is used and the "slower" version drops back when required.