### PR TITLE
Allow sort of operationames with leading spaces

### DIFF
--- a/Version Control.accda.src/modules/clsPerformance.cls
+++ b/Version Control.accda.src/modules/clsPerformance.cls
@@ -608,7 +608,7 @@ Private Function SortItemsByTime(dItems As Dictionary) As Dictionary
     ' Build our list of records
     For Each varKey In dItems.Keys
         ' Create a record like this: "00062840.170000|Export Form Objects       ..."
-        strRecord = Format$(dItems(varKey).Total, "00000000.000000") & "|" & PadRight(CStr(varKey), 255)
+        strRecord = Format$(dItems(varKey).Total, "00000000.000000") & "|" & CStr(varKey)
         ' Add to array.
         varItems(lngCnt) = strRecord
         ' Increment counter for array
@@ -624,7 +624,7 @@ Private Function SortItemsByTime(dItems As Dictionary) As Dictionary
     For lngCnt = dItems.Count - 1 To 0 Step -1
         ' Parse key from record (text after first pipe character)
         strRecord = varItems(lngCnt)
-        varKey = Trim$(Mid$(strRecord, InStr(1, strRecord, "|") + 1))
+        varKey = Mid$(strRecord, InStr(1, strRecord, "|") + 1)
         ' Reference performance item class
         Set cItem = dItems(varKey)
         ' Add to dictionary of resorted items


### PR DESCRIPTION
If a operationname has a leading space (like " MyOperation" ) the function "SortItemsByTime" fails. 
Now sorting will success.