### PR TITLE
Fixes #503

### DIFF
--- a/Version Control.accda.src/forms/frmVCSMain.cls
+++ b/Version Control.accda.src/forms/frmVCSMain.cls
@@ -28,6 +28,7 @@ Public strLastLogFilePath As String
 ' Use this property to set the path to the source files (such as a build triggered from the API)
 Public strSourcePath As String
 
+Public FormOpenedExternally As Boolean ' Set True externally when opened by other entity.
 
 '---------------------------------------------------------------------------------------
 ' Procedure : cmdBuild_Click
@@ -419,6 +420,9 @@ Public Sub AutoClose()
     'In this case, a VBA error may occur, so we check if the
     'form is loaded before setting the property. We do not use
     'the Me.Name because that would be also an error.
+
+    If Not FormOpenedExternally Then Exit Sub
+
     If IsLoaded(acForm, "frmVCSMain", False) Then
         Me.TimerInterval = 2000
     End If

--- a/Version Control.accda.src/modules/clsVersionControl.cls
+++ b/Version Control.accda.src/modules/clsVersionControl.cls
@@ -26,7 +26,7 @@ Option Explicit
 '---------------------------------------------------------------------------------------
 '
 Public Sub Show()
-    DoCmd.OpenForm "frmVCSMain"
+    OpenVCSMainForm acWindowNormal
 End Sub
 
 
@@ -76,7 +76,9 @@ End Sub
 '---------------------------------------------------------------------------------------
 '
 Public Sub ExportSelected()
+
     Dim objSelected As AccessObject
+
     Set objSelected = GetSelectedNavPaneObject
     If objSelected Is Nothing Then
         MsgBox2 "Please Select an Object First", _
@@ -86,6 +88,7 @@ Public Sub ExportSelected()
         ' Export the item
         RunExport , objSelected
     End If
+
 End Sub
 
 
@@ -96,9 +99,10 @@ End Sub
 ' Purpose   : Handle different kinds of exports based on filter
 '---------------------------------------------------------------------------------------
 '
-Private Sub RunExport(Optional intFilter As eContainerFilter = ecfAllObjects, Optional objItem As AccessObject)
-    DoCmd.OpenForm "frmVCSMain", , , , , acHidden
-    With Form_frmVCSMain
+Private Sub RunExport(Optional intFilter As eContainerFilter = ecfAllObjects _
+                    , Optional objItem As AccessObject)
+
+    With OpenVCSMainForm
         If objItem Is Nothing Then
             .intContainerFilter = intFilter
         Else
@@ -108,6 +112,7 @@ Private Sub RunExport(Optional intFilter As eContainerFilter = ecfAllObjects, Op
         .cmdExport_Click
         If Log.ErrorLevel < eelError Then .AutoClose
     End With
+
 End Sub
 
 
@@ -119,13 +124,14 @@ End Sub
 '---------------------------------------------------------------------------------------
 '
 Public Sub Build(Optional strSourceFolder As String)
-    DoCmd.OpenForm "frmVCSMain", , , , , acHidden
-    With Form_frmVCSMain
+
+    With OpenVCSMainForm
         ' Make sure we are doing a full build.
         If Not .chkFullBuild Then .chkFullBuild = True
         .strSourcePath = strSourceFolder
         .cmdBuild_Click
     End With
+
 End Sub
 
 
@@ -137,8 +143,8 @@ End Sub
 '---------------------------------------------------------------------------------------
 '
 Public Sub MergeBuild()
-    DoCmd.OpenForm "frmVCSMain", , , , , acHidden
-    With Form_frmVCSMain
+
+    With OpenVCSMainForm
         ' See if merge build is available
         If .chkFullBuild.Enabled Then
             ' Initiate the merge build
@@ -150,7 +156,31 @@ Public Sub MergeBuild()
                 "Please perform a full build of this database first.", vbInformation
         End If
     End With
+
 End Sub
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : OpenVCSMainForm
+' Author    : hecon5
+' Date      : 2024 MAR 27
+' Purpose   : Open frmVCSMain and set external flag.
+'---------------------------------------------------------------------------------------
+'
+Private Function OpenVCSMainForm(Optional ByVal OpenMode As AcWindowMode = acHidden) As Access.Form
+
+    If Not IsLoaded(acForm, "frmVCSMain", False) Then
+
+        DoCmd.OpenForm "frmVCSMain", , , , , OpenMode
+        With Form_frmVCSMain
+            .FormOpenedExternally = True
+        End With
+
+    End If
+
+    Set OpenVCSMainForm = Form_frmVCSMain
+
+End Function
 
 
 '---------------------------------------------------------------------------------------
@@ -270,10 +300,11 @@ Public Sub LoadSelected()
         Set objSelected = Nothing
 
         ' Import the object from source files
-        DoCmd.OpenForm "frmVCSMain", , , , , acHidden
-        Form_frmVCSMain.StartBuild False
-        LoadSingleObject cComponentClass, strObjectName, strSourceFilePath
-        Form_frmVCSMain.FinishBuild False
+        With OpenVCSMainForm
+            .StartBuild False
+            LoadSingleObject cComponentClass, strObjectName, strSourceFilePath
+            .FinishBuild False
+        End With
     End If
 
 End Sub


### PR DESCRIPTION
Attempt 2 after I borked my branching.

This Fixes #503.

I added an external Boolean to `frmVCSMain` to aid in detecting whether the form was opened externally or not; and changed how `clsVersionControl` loads the form and references it.

A new function now detects if a form is already open, and returns with the form as a reference. This allows the same entrance code to be used everywhere in the module and won't alter the form's visibility when it is open and then the ribbon is clicked.

I'm doing some more testing, should be ready in just a moment.