### PR TITLE
Enable comand bars and bug fixes

### DIFF
--- a/Version Control.accda.src/dbs-properties.json
+++ b/Version Control.accda.src/dbs-properties.json
@@ -41,7 +41,7 @@
       "Type": 10
     },
     "AppVersion": {
-      "Value": "4.0.37",
+      "Value": "4.0.38",
       "Type": 10
     },
     "Auto Compact": {

--- a/Version Control.accda.src/forms/frmVCSOptions.cls
+++ b/Version Control.accda.src/forms/frmVCSOptions.cls
@@ -343,41 +343,43 @@ Private Sub LoadTableList()
 
     ' Get list of tables if we have a database file open.
     If DatabaseFileOpen Then
+        ' ADP does not have local tables. Export data is probably best handled with SQL Server tools.
+        If Not (CurrentProject.ProjectType = acADP) Then
+            ' Note that Access SQL does not support bitwise "and" operator
+            ' (Also known as BAND in ADO) so we will check the bit flags in VBA instead.
+            strSql = _
+                "SELECT o.Name, o.Type, o.Flags " & _
+                "FROM MSysObjects AS o " & _
+                "WHERE o.Type IN (1, 4, 6) " & _
+                "ORDER BY o.Name;"
 
-        ' Note that Access SQL does not support bitwise "and" operator
-        ' (Also known as BAND in ADO) so we will check the bit flags in VBA instead.
-        strSql = _
-            "SELECT o.Name, o.Type, o.Flags " & _
-            "FROM MSysObjects AS o " & _
-            "WHERE o.Type IN (1, 4, 6) " & _
-            "ORDER BY o.Name;"
-
-        Set rstSource = CurrentDb.OpenRecordset(strSql, dbOpenSnapshot)
-        With rstSource
-            Do While Not .EOF
-                ' Determine type of table
-                lngFlags = Nz(!Flags, 0)
-                lngType = Nz(!Type, 0)
-                If (lngFlags < 0) Or BitSet(lngFlags, 1) Then
-                    ' Don't include read-only or deeply hidden system tables.
-                    ' https://isladogs.co.uk/purpose-of-system-tables-2/index.html#TFE
-                Else
-                    rstTableData.AddNew
-                        rstTableData!TableName = Nz(!Name)
-                        rstTableData!Flags = Nz(!Flags)
-                        rstTableData!IsSystem = BitSet(lngFlags, 2)
-                        rstTableData!IsHidden = BitSet(lngFlags, 8)
-                        rstTableData!IsLocal = (lngType = 1)
-                        ' Determine table icon
-                        rstTableData!TableIcon = GetTableIcon(etcLinked)    ' Default to linked table if no match.
-                        If rstTableData!IsLocal Then rstTableData!TableIcon = GetTableIcon(etcLocal)
-                        If rstTableData!IsSystem Then rstTableData!TableIcon = GetTableIcon(etcSystem)
-                    rstTableData.Update
-                End If
-                .MoveNext
-            Loop
-            .Close
-        End With
+            Set rstSource = CurrentDb.OpenRecordset(strSql, dbOpenSnapshot)
+            With rstSource
+                Do While Not .EOF
+                    ' Determine type of table
+                    lngFlags = Nz(!Flags, 0)
+                    lngType = Nz(!Type, 0)
+                    If (lngFlags < 0) Or BitSet(lngFlags, 1) Then
+                        ' Don't include read-only or deeply hidden system tables.
+                        ' https://isladogs.co.uk/purpose-of-system-tables-2/index.html#TFE
+                    Else
+                        rstTableData.AddNew
+                            rstTableData!TableName = Nz(!Name)
+                            rstTableData!Flags = Nz(!Flags)
+                            rstTableData!IsSystem = BitSet(lngFlags, 2)
+                            rstTableData!IsHidden = BitSet(lngFlags, 8)
+                            rstTableData!IsLocal = (lngType = 1)
+                            ' Determine table icon
+                            rstTableData!TableIcon = GetTableIcon(etcLinked)    ' Default to linked table if no match.
+                            If rstTableData!IsLocal Then rstTableData!TableIcon = GetTableIcon(etcLocal)
+                            If rstTableData!IsSystem Then rstTableData!TableIcon = GetTableIcon(etcSystem)
+                        rstTableData.Update
+                    End If
+                    .MoveNext
+                Loop
+                .Close
+            End With
+        End If
     End If
 
     ' Add in the list of saved tables, adding into the sorted location
@@ -429,22 +431,24 @@ Private Sub SaveTableList()
     Set dTables = New Dictionary
     dTables.CompareMode = TextCompare
 
-    Set rstTableData = CodeDb.OpenRecordset( _
-        "SELECT TableName, FormatType FROM tblTableData " & _
-        "WHERE FormatType <> 0 ORDER BY TableName;", dbOpenForwardOnly)
-    With rstTableData
-        Do Until .EOF
-            Set dTable = New Dictionary
-            dTable.CompareMode = TextCompare
-            dTable("Format") = Options.GetTableExportFormatName(Nz(!FormatType, 0))
-            dTables.Add Nz(!TableName), dTable
-            .MoveNext
-        Loop
-        .Close
-    End With
+    ' ADP project type shouldn't export data; set it as an empty list.
+    If Not (CurrentProject.ProjectType = acADP) Then
+        Set rstTableData = CodeDb.OpenRecordset( _
+            "SELECT TableName, FormatType FROM tblTableData " & _
+            "WHERE FormatType <> 0 ORDER BY TableName;", dbOpenForwardOnly)
+        With rstTableData
+            Do Until .EOF
+                Set dTable = New Dictionary
+                dTable.CompareMode = TextCompare
+                dTable("Format") = Options.GetTableExportFormatName(Nz(!FormatType, 0))
+                dTables.Add Nz(!TableName), dTable
+                .MoveNext
+            Loop
+            .Close
+        End With
+    End If
 
     Set Options.TablesToExportData = dTables
-
 End Sub
 
 

--- a/Version Control.accda.src/modules/clsDbCommandBar.cls
+++ b/Version Control.accda.src/modules/clsDbCommandBar.cls
@@ -20,6 +20,7 @@ Option Explicit
 Private m_CommandBar As CommandBar
 Private m_Items(True To False) As Dictionary
 Private m_dItems As Dictionary
+Private m_FileList As Dictionary
 
 Private Type udtThis
     BarProperties As Collection
@@ -119,7 +120,24 @@ Private Sub IDbComponent_Import(strFile As String)
 
     ' Now, create a new command bar, and add controls to it.
     Perf.OperationStart "Building CommandBar"
-    Set m_CommandBar = CommandBars.Add(strName, msoBarPopup, , False)
+    Dim IsMenu As Boolean
+    Dim Position As MsoBarPosition
+
+    Position = -1 'set to invalid value to simulate the "missing" value which cannot be directly set in VBA...
+    IsMenu = (dBar("Items").Item("Type") = msoBarTypeMenuBar)
+    If CatchAny(eelNoError, vbNullString) Then
+        IsMenu = False
+    End If
+    Position = dBar("Items").Item("Position")
+    If CatchAny(eelNoError, vbNullString) Then
+        Position = -1
+    End If
+
+    If Position = -1 Then
+        Set m_CommandBar = CommandBars.Add(strName, , IsMenu, False)
+    Else
+        Set m_CommandBar = CommandBars.Add(strName, Position, IsMenu, False)
+    End If
     BuildControls dBar("Items"), m_CommandBar
     Perf.OperationEnd
 
@@ -133,7 +151,7 @@ End Sub
 
 
 '---------------------------------------------------------------------------------------
-' Procedure : BuildMenu
+' Procedure : BuildControls
 ' Author    : Adam Waller
 ' Date      : 1/13/2024
 ' Purpose   : Recursive function to build the controls on the popup menu
@@ -266,7 +284,7 @@ End Function
 
 
 '---------------------------------------------------------------------------------------
-' Procedure : BuildElements
+' Procedure : BuildElementDictionary
 ' Author    : Adam Waller
 ' Date      : 1/12/2024
 ' Purpose   : A recursive function to build out the dictionary elements representing
@@ -484,8 +502,8 @@ End Function
 '---------------------------------------------------------------------------------------
 '
 Private Function IDbComponent_GetFileList() As Dictionary
-    Set IDbComponent_GetFileList = New Dictionary
-    If FSO.FileExists(IDbComponent_SourceFile) Then IDbComponent_GetFileList.Add IDbComponent_SourceFile, vbNullString
+    If m_FileList Is Nothing Then Set m_FileList = GetFilePathsInFolder(IDbComponent_BaseFolder, "*.json")
+    Set IDbComponent_GetFileList = m_FileList
 End Function
 
 
@@ -671,6 +689,7 @@ Private Sub Class_Initialize()
         .Add "Top"
         .Add "Type"
         .Add "Width"
+        .Add "Position"
     End With
 
     ' CommmandBarControl Properties

--- a/Version Control.accda.src/modules/clsDbCommandBar.cls
+++ b/Version Control.accda.src/modules/clsDbCommandBar.cls
@@ -314,18 +314,21 @@ Private Function BuildElementDictionary(dParent As Dictionary, objItem As Object
         Else
             ' Check for picture
             Set picItem = objItem.Picture
-            If Not picItem Is Nothing Then
-                strPath = GetImagePath(objItem)
-                ' Check path for possible duplicates (menu items with the same name)
-                If this.dImages.Exists(strPath) Then
-                    ' Add a number to make the path unique.
-                    strPath = strPath & this.dImages.Count & "_"
+            ' Not all command bar controls have picture
+            If Not CatchAny(eelNoError, vbNullString) Then
+                If Not picItem Is Nothing Then
+                    strPath = GetImagePath(objItem)
+                    ' Check path for possible duplicates (menu items with the same name)
+                    If this.dImages.Exists(strPath) Then
+                        ' Add a number to make the path unique.
+                        strPath = strPath & this.dImages.Count & "_"
+                    End If
+                    ' Save reference to image objects to use when
+                    ' exporting images to files.
+                    this.dImages.Add strPath, objItem
+                    ' Save path to images in element dictionary
+                    dParent.Add "ImagePath", GetRelativePath(strPath)
                 End If
-                ' Save reference to image objects to use when
-                ' exporting images to files.
-                this.dImages.Add strPath, objItem
-                ' Save path to images in element dictionary
-                dParent.Add "ImagePath", GetRelativePath(strPath)
             End If
         End If
     Else

--- a/Version Control.accda.src/modules/modSqlFunctions.bas
+++ b/Version Control.accda.src/modules/modSqlFunctions.bas
@@ -132,7 +132,7 @@ Public Function GetSQLObjectDefinitionForADP(strName As String) As String
     ' Simple validation on object name
     strObject = Replace(strName, ";", vbNullString)
 
-    strSql = "SELECT object_definition (OBJECT_ID(N'" & strObject & "'))"
+    strSql = "SELECT object_definition (OBJECT_ID(N'" & Replace$(strObject, "'", "''") & "'))"
     '@Ignore SetAssignmentWithIncompatibleObjectType
     Set rst = CurrentProject.Connection.Execute(strSql)
     If Not rst.EOF Then

--- a/Version Control.accda.src/modules/modVCSUtility.bas
+++ b/Version Control.accda.src/modules/modVCSUtility.bas
@@ -57,7 +57,7 @@ Public Function GetContainers(Optional intFilter As eContainerFilter = ecfAllObj
                 .Add New clsDbVbeForm
                 .Add New clsDbProjProperty
                 .Add New clsDbSavedSpec
-                '.Add New clsDbCommandBar
+                .Add New clsDbCommandBar
                 If blnADP Then
                     ' Some types of objects only exist in ADP projects
                     .Add New clsAdpFunction


### PR DESCRIPTION
This enables the support for command bars import/export which was introduced a while ago but was not enabled.

Furthermore, it was throwing an error when exporting. That was due to some command bars not containing a `Picture` property and the attempt to extract the picture was not wrapped in a `CatchAny` directive, resulting in spurious error entries in the log. 

This also includes a bug fix for handling the table data in an ADP project. Because I don't think handling local table data makes sense for an ADP project, I opted to bypass the load/save which also avoids an error due to invalid reference to the `CurrentDb` in an ADP project. 

Wanted to put it out and get feedback before merging. 