### PR TITLE
Fix566 

### DIFF
--- a/Version Control.accda.src/dbs-properties.json
+++ b/Version Control.accda.src/dbs-properties.json
@@ -41,7 +41,7 @@
       "Type": 10
     },
     "AppVersion": {
-      "Value": "4.0.39",
+      "Value": "4.1.0",
       "Type": 10
     },
     "Auto Compact": {

--- a/Version Control.accda.src/forms/frmVCSOptions.bas
+++ b/Version Control.accda.src/forms/frmVCSOptions.bas
@@ -1102,7 +1102,7 @@ Begin Form
                                     OverlapFlags =247
                                     Left =1020
                                     Top =3360
-                                    TabIndex =4
+                                    TabIndex =2
                                     Name ="chkExtractThemeFiles"
 
                                     LayoutCachedLeft =1020
@@ -1138,7 +1138,7 @@ Begin Form
                                     Top =3720
                                     Width =1980
                                     Height =315
-                                    TabIndex =2
+                                    TabIndex =3
                                     Name ="cboSanitizeLevel"
                                     RowSourceType ="Value List"
                                     ColumnWidths ="0"
@@ -1176,7 +1176,7 @@ Begin Form
                                     Top =4140
                                     Width =1980
                                     Height =315
-                                    TabIndex =3
+                                    TabIndex =4
                                     Name ="cboSanitizeColors"
                                     RowSourceType ="Value List"
                                     ColumnWidths ="0"

--- a/Version Control.accda.src/forms/frmVCSOptions.cls
+++ b/Version Control.accda.src/forms/frmVCSOptions.cls
@@ -820,17 +820,21 @@ Private Sub OnOptionChange(ByVal strName As String _
                             , Optional ByRef ctlChecked As Control)
 
     Dim blnChanged As Boolean
+    Dim varOldValue As Variant
 
     ' Determine if the option was changed
-    blnChanged = Not (CVar(CallByName(Options, strName, VbGet)) = varNewValue)
+    ' We use the old value a few times (namely for Sanization checks), and this can help other checks
+    ' and avoid additional calls to Options.
+    varOldValue = CVar(CallByName(Options, strName, VbGet))
+    blnChanged = Not (varOldValue = varNewValue)
     If Not blnChanged Then Exit Sub
 
     ' Define actual rules here
     Select Case strName
 
         Case "SanitizeColors", "SanitizeLevel"
-            CallByName Options, strName, VbLet, Options.CheckSanitizeLevel(varNewValue, CallByName(Options, strName, VbGet))
-            ctlChecked.Value = CallByName(Options, strName, VbGet)
+            'CallByName Options, strName, VbLet, Options.CheckSanitizeLevel(varNewValue, )
+            ctlChecked = Options.CheckSanitizeLevel(varNewValue, varOldValue)
         ' If a user turns on the option to split files
         Case "SplitLayoutFromVBA"
             If varNewValue = True Then

--- a/Version Control.accda.src/forms/frmVCSOptions.cls
+++ b/Version Control.accda.src/forms/frmVCSOptions.cls
@@ -699,7 +699,7 @@ Private Sub Form_Load()
     ' Load general sanitize options
     With Me.cboSanitizeLevel
         .RowSource = vbNullString
-        For intSanitizeLevel = 0 To (eSanitizeLevel.[_Last] - 1)
+        For intSanitizeLevel = eSanitizeLevel.eslNone To (eSanitizeLevel.[_Last] - 1)
             .AddItem intSanitizeLevel & ";" & Options.GetSanitizeLevelName(intSanitizeLevel)
         Next intSanitizeLevel
     End With
@@ -707,7 +707,7 @@ Private Sub Form_Load()
     ' Load color sanitize options
     With Me.cboSanitizeColors
         .RowSource = vbNullString
-        For intSanitizeLevel = 0 To (eSanitizeLevel.[_Last] - 1)
+        For intSanitizeLevel = eSanitizeLevel.eslNone To (eSanitizeLevel.[_Last] - 1)
             .AddItem intSanitizeLevel & ";" & Options.GetSanitizeLevelName(intSanitizeLevel)
         Next intSanitizeLevel
     End With
@@ -776,7 +776,7 @@ Private Sub MapControlsToOptions(eAction As eMapAction)
                                     ctl = CallByName(Options, strKey, VbGet)
                                 ElseIf eAction = emaFormToClass Then
                                     ' Check for any hooks on option change
-                                    OnOptionChange strKey, Nz(ctl.Value)
+                                    OnOptionChange strKey, Nz(ctl.Value), ctl
                                     ' Set the option value
                                     CallByName Options, strKey, VbLet, Nz(ctl.Value)
                                 End If
@@ -815,7 +815,9 @@ End Sub
 '           : from their existing values. Add any specific rules here.
 '---------------------------------------------------------------------------------------
 '
-Private Sub OnOptionChange(strName As String, varNewValue As Variant)
+Private Sub OnOptionChange(ByVal strName As String _
+                            , ByRef varNewValue As Variant _
+                            , Optional ByRef ctlChecked As Control)
 
     Dim blnChanged As Boolean
 
@@ -826,6 +828,9 @@ Private Sub OnOptionChange(strName As String, varNewValue As Variant)
     ' Define actual rules here
     Select Case strName
 
+        Case "SanitizeColors", "SanitizeLevel"
+            CallByName Options, strName, VbLet, Options.CheckSanitizeLevel(varNewValue, CallByName(Options, strName, VbGet))
+            ctlChecked.Value = CallByName(Options, strName, VbGet)
         ' If a user turns on the option to split files
         Case "SplitLayoutFromVBA"
             If varNewValue = True Then

--- a/Version Control.accda.src/modules/clsOptions.cls
+++ b/Version Control.accda.src/modules/clsOptions.cls
@@ -65,6 +65,8 @@ Private m_dEnum As Dictionary
 Private m_strOptionsFilePath As String
 Private m_strLoadedVersion As String
 
+'
+Private m_SaveAfterInitializeUpgrade As Boolean ' Used to indicate a save operation should occur after upgrade.
 
 '---------------------------------------------------------------------------------------
 ' Procedure : LoadDefaults
@@ -227,12 +229,17 @@ End Sub
 '
 Public Sub LoadOptionsFromFile(strFile As String)
 
+    Dim FunctionName As String
+
     Dim dFile As Dictionary
     Dim dOptions As Dictionary
     Dim varOption As Variant
     Dim strKey As String
 
-    If DebugMode(True) Then On Error GoTo 0 Else On Error Resume Next
+    FunctionName = ModuleName(Me) & ".LoadOptionsFromFile"
+
+    LogUnhandledErrors FunctionName
+    On Error Resume Next
 
     ' Save file path, in case we need to use it to determine
     ' the export folder location with no database open.
@@ -271,7 +278,7 @@ Public Sub LoadOptionsFromFile(strFile As String)
     ' Set the build path property when loading options
     SetBuildPath
 
-    CatchAny eelError, "Loading options from " & strFile, ModuleName(Me) & ".LoadOptionsFromFile"
+    CatchAny eelError, "Loading options from " & strFile, FunctionName
 
 End Sub
 
@@ -352,11 +359,18 @@ End Function
 '
 Private Sub Upgrade(ByRef dOptions As Dictionary)
 
+    Dim FunctionName As String
+
     Dim varKey As Variant
     Dim dItem As Dictionary
     Dim varItems As Variant
     Dim colItems As Collection
     Dim varLine As Variant
+
+    FunctionName = ModuleName(Me) & ".Upgrade"
+
+    LogUnhandledErrors FunctionName
+    On Error Resume Next
 
     ' 6/16/2021
     ' Aggressive sanitize to sanitize levels
@@ -369,6 +383,11 @@ Private Sub Upgrade(ByRef dOptions As Dictionary)
             End If
         End If
     End If
+    CatchAny eelError, "Error upgrading legacy sanitize setting.", FunctionName
+
+    ' 2025-Jan-31
+    If dOptions.Exists("SanitizeLevel") Then dOptions("SanitizeLevel") = CheckSanitizeLevel(dOptions("SanitizeLevel"))
+    If dOptions.Exists("SanitizeColors") Then dOptions("SanitizeColors") = CheckSanitizeLevel(dOptions("SanitizeColors"))
 
     ' 11/3/2023
     ' Check option to split VBA from object layout
@@ -386,6 +405,7 @@ Private Sub Upgrade(ByRef dOptions As Dictionary)
             ' the default setting.
         End If
     End If
+    CatchAny eelError, "Error upgrading Color Options.", FunctionName
 
     ' 1/9/2024 (4.0.31)
     ' Use collection to store schema filter entries
@@ -409,6 +429,8 @@ Private Sub Upgrade(ByRef dOptions As Dictionary)
             Next varKey
         End If
     End If
+
+    CatchAny eelError, "Upgrading options.", FunctionName
 
 End Sub
 
@@ -642,6 +664,51 @@ End Function
 
 
 '---------------------------------------------------------------------------------------
+' Procedure : CheckSanitizeLevel
+' Author    : Hecon5
+' Date      : 2024-Jan-31
+' Purpose   : Check Sanitize level and warn if off.
+'---------------------------------------------------------------------------------------
+'
+Public Function CheckSanitizeLevel(ByVal intNewSanitizeLevel As eSanitizeLevel _
+                                    , Optional ByVal intPriorSanitizeLevel As eSanitizeLevel = eSanitizeLevel.eslMinimal)
+    ' strongly suggest eslNone is not used as it causes significant problems with
+    ' building.
+    ' Ask user every options load to upgrade.
+    Dim intTempPriorSanitizeLevel As eSanitizeLevel
+
+    intTempPriorSanitizeLevel = IIf(intPriorSanitizeLevel >= eslMinimal, intPriorSanitizeLevel, eslMinimal)
+
+    If intNewSanitizeLevel = eslNone Then
+        If MsgBox2(T("Warning: Sanitize level set to {0}. This will likely cause problems with building from source." _
+                    , var0:=GetSanitizeLevelName(intNewSanitizeLevel)) _
+                , T("It is recommended to set sanitization to at least {1}. Find Sanitization settings in Options > Export Tab." _
+                    , var1:=GetSanitizeLevelName(eslMinimal)) _
+                , T("Set to '{0}'?" & vbNewLine & vbNewLine & _
+                   "[Yes] = Set to '{0}'." & vbNewLine & vbNewLine & _
+                   "[No] = Leave setting. I understand this may cause problems on build." _
+                    , var0:=GetSanitizeLevelName(intTempPriorSanitizeLevel)) _
+                , vbDefaultButton1 + vbExclamation + vbYesNo _
+                , T("Sanitization Level Alert")) = vbYes Then
+
+                If intPriorSanitizeLevel > eslNone Then
+                    CheckSanitizeLevel = intPriorSanitizeLevel
+                Else
+                    CheckSanitizeLevel = eSanitizeLevel.eslMinimal
+                End If
+                m_SaveAfterInitializeUpgrade = True ' request a save if this is a class initialization.
+        Else
+            CheckSanitizeLevel = intNewSanitizeLevel
+        End If
+
+    Else
+        CheckSanitizeLevel = intNewSanitizeLevel
+    End If
+
+End Function
+
+
+'---------------------------------------------------------------------------------------
 ' Procedure : GetSanitizeLevelName
 ' Author    : Hecon5 (as adapted from Adam Waller's below)
 ' Date      : 6/09/2021
@@ -768,6 +835,7 @@ Private Sub Class_Initialize()
 
     ' Load saved defaults
     LoadDefaultOptions
+    If m_SaveAfterInitializeUpgrade Then Me.SaveOptionsForProject
 
     ' Other run-time options
     JsonOptions.AllowUnicodeChars = True

--- a/Version Control.accda.src/modules/clsOptions.cls
+++ b/Version Control.accda.src/modules/clsOptions.cls
@@ -65,8 +65,9 @@ Private m_dEnum As Dictionary
 Private m_strOptionsFilePath As String
 Private m_strLoadedVersion As String
 
-'
-Private m_SaveAfterInitializeUpgrade As Boolean ' Used to indicate a save operation should occur after upgrade.
+' Used to indicate a save operation should occur after upgrade.
+Private m_SaveAfterInitializeUpgrade As Boolean
+
 
 '---------------------------------------------------------------------------------------
 ' Procedure : LoadDefaults
@@ -386,8 +387,8 @@ Private Sub Upgrade(ByRef dOptions As Dictionary)
     CatchAny eelError, "Error upgrading legacy sanitize setting.", FunctionName
 
     ' 2025-Jan-31
-    If dOptions.Exists("SanitizeLevel") Then dOptions("SanitizeLevel") = CheckSanitizeLevel(dOptions("SanitizeLevel"))
-    If dOptions.Exists("SanitizeColors") Then dOptions("SanitizeColors") = CheckSanitizeLevel(dOptions("SanitizeColors"))
+    If dOptions.Exists("SanitizeLevel") And Not OptionsLoaded Then dOptions("SanitizeLevel") = CheckSanitizeLevel(dOptions("SanitizeLevel"))
+    If dOptions.Exists("SanitizeColors") And Not OptionsLoaded Then dOptions("SanitizeColors") = CheckSanitizeLevel(dOptions("SanitizeColors"))
 
     ' 11/3/2023
     ' Check option to split VBA from object layout
@@ -697,6 +698,7 @@ Public Function CheckSanitizeLevel(ByVal intNewSanitizeLevel As eSanitizeLevel _
                     CheckSanitizeLevel = eSanitizeLevel.eslMinimal
                 End If
                 m_SaveAfterInitializeUpgrade = True ' request a save if this is a class initialization.
+
         Else
             CheckSanitizeLevel = intNewSanitizeLevel
         End If

--- a/Version Control.accda.src/modules/modAPI.bas
+++ b/Version Control.accda.src/modules/modAPI.bas
@@ -28,7 +28,7 @@ End Enum
 ' Sanitize levels used for sanitizing general and color elements in source files.
 Public Enum eSanitizeLevel
     eslNone = 0     ' Don't sanitize anything.
-    eslMinimal      ' Sanitize minimal things like GUIDs.
+    eslMinimal = 1  ' Sanitize minimal things like GUIDs.
     eslStandard     ' Remove non-critical elements that cause VCS noise between builds.
     eslExtended     ' Remove as much as possible. May have possible negative effects.
     [_Last]         ' Placeholder for the end of the list.


### PR DESCRIPTION
This fixes #554.

Summary:  
- Add upgrade tooling to notify user using `eslNone` may cause issues. 
- Tooling will provide path to revert to prior (or suggested) setting.
- Add routine to save options after upgrade to ensure change is logged.
- Add routine to options screen so that when users attempt to set to Off they're aware of potential issues.
- Fix Tab order of controls on Options Form.
- Bump version to 4.1.0.

BUMP VERSION to 4.1.0. 
- This is because it is a potentially significant code change to outputs if users upgrade. Many users will not see this (especially those who use the default values). 
- 