### PR TITLE
Forms are not imported (clsDbForm: LoadComponentFromText with acReport instead of acForm)

### DIFF
--- a/Version Control.accda.src/modules/clsDbForm.cls
+++ b/Version Control.accda.src/modules/clsDbForm.cls
@@ -71,7 +71,7 @@ Private Sub IDbComponent_Import(strFile As String)
     End If
 
     ' Load the form from the source file
-    blnImportCheck = LoadComponentFromText(acReport, strName, strFile)
+    blnImportCheck = LoadComponentFromText(acForm, strName, strFile)
     If Not blnImportCheck Or Log.ErrorLevel = eelCritical Then Exit Sub
     Set m_Form = CurrentProject.AllForms(strName)
     VCSIndex.Update Me, eatImport, GetCodeModuleHash(IDbComponent_ComponentType, strName)


### PR DESCRIPTION
clsDbForm: LoadComponentFromText(acReport, strName, strFile) => Forms cannot be imported.
Fix: LoadComponentFromText(acForm, strName, strFile)
