### PR TITLE
modDatabase.RunSubInCurrentProject / modAPI.RunInAddIn: avoid rename VBProject

### DIFF
--- a/Version Control.accda.src/modules/modDatabase.bas
+++ b/Version Control.accda.src/modules/modDatabase.bas
@@ -554,13 +554,16 @@ Public Sub RunSubInCurrentProject(strSubName As String)
 
     ' Check for add-in project name
     If StrComp(CurrentVBProject.Name, GetAddInProject.Name, vbTextCompare) = 0 Then
-        ' Temporarily rename the add-in project so the sub runs in the current project.
-        GetAddInProject.Name = "MSAccessVCS-Lib"
-        Application.Run strCmd
-        GetAddInProject.Name = PROJECT_NAME
-    Else
-        Application.Run strCmd
+        ' Temporarily rename the add-in project so the sub runs in the current project ... Not required: call with full name
+        Dim VbProjectFilenameWithoutFileExt As String
+        Const AddInFileExtension As String = ".accda"
+        With CurrentVBProject
+            VbProjectFilenameWithoutFileExt = Left(.FileName, Len(.FileName) - Len(AddInFileExtension))
+            strCmd = Replace(strCmd, "[" & .Name & "]", VbProjectFilenameWithoutFileExt)
+        End With
     End If
+
+    Application.Run strCmd
 
 End Sub
 


### PR DESCRIPTION
The VBProject is currently being renamed so that Application.Run uses the correct procedure.
Alternatively, you could use the full path without file extension.
```Application.Run "c:\....\Version Control." & ProcedureName```

This variant has the advantage that it also works with a compiled add-in.

This pull request includes several changes in the `modAPI.bas` (`RunInAddIn`) and `modDatabase.bas` (`RunSubInCurrentProject`) modules. The changes focus on improving the way the add-in project name is handled and simplifying the execution of procedures.