### PR TITLE
Handle user-defined properties and troublesome queries

### DIFF
--- a/Version Control.accda.src/documents.json
+++ b/Version Control.accda.src/documents.json
@@ -6,9 +6,18 @@
   "Items": {
     "Databases": {
       "SummaryInfo": {
-        "Comments": "Export source code and database objects for tracking in Version Control Systems like GitHub and GitLab. Also used for building a database from source files.",
-        "Company": "https://github.com/joyfullservice/msaccess-vcs-addin",
-        "Title": "Version Control"
+        "Comments": {
+          "Type": 10,
+          "Value": "Export source code and database objects for tracking in Version Control Systems like GitHub and GitLab. Also used for building a database from source files."
+        },
+        "Company": {
+          "Type": 10,
+          "Value": "https://github.com/joyfullservice/msaccess-vcs-addin"
+        },
+        "Title": {
+          "Type": 10,
+          "Value": "Version Control"
+        }
       }
     }
   }

--- a/Version Control.accda.src/modules/clsDbDocument.cls
+++ b/Version Control.accda.src/modules/clsDbDocument.cls
@@ -37,7 +37,11 @@ Implements IDbComponent
 Private Sub IDbComponent_Export(Optional strAlternatePath As String)
     Dim strContent As String
     strContent = GetSource
-    WriteFile strContent, Nz2(strAlternatePath, IDbComponent_SourceFile)
+    If strContent = vbNullString Then
+        If FSO.FileExists(IDbComponent_SourceFile) Then DeleteFile IDbComponent_SourceFile
+    Else
+        WriteFile strContent, Nz2(strAlternatePath, IDbComponent_SourceFile)
+    End If
     VCSIndex.Update Me, IIf(strAlternatePath = vbNullString, eatExport, eatAltExport), GetStringHash(strContent, True)
 End Sub
 
@@ -116,7 +120,10 @@ Private Sub IDbComponent_Merge(strFile As String)
     ' Remove any document properties that don't exist in the incoming file,
     ' then import the file.
     Set dFile = ReadJsonFile(strFile)
-    If dFile Is Nothing Then Set dFile = New Dictionary
+    If dFile Is Nothing Then
+        Set dFile = New Dictionary
+        Set dFile("Items") = New Dictionary
+    End If
     RemoveMissing dFile("Items"), GetDictionary
 
     ' Import if file exists
@@ -191,7 +198,6 @@ End Function
 Private Function GetDictionary(Optional blnUseCache As Boolean = True) As Dictionary
 
     Dim prp As DAO.Property
-    Dim dItems As Dictionary    ' All Items
     Dim dCont As Dictionary     ' Container
     Dim dDoc As Dictionary      ' Document
     Dim cont As DAO.Container
@@ -207,7 +213,7 @@ Private Function GetDictionary(Optional blnUseCache As Boolean = True) As Dictio
     End If
 
     ' Create dictionary object to hold all the items
-    Set dItems = New Dictionary
+    Set m_dItems = New Dictionary
     Set dbs = CurrentDb
 
     ' Loop through all the containers, documents, and properties.
@@ -264,11 +270,11 @@ Private Function GetDictionary(Optional blnUseCache As Boolean = True) As Dictio
             Next prp
             If dDoc.Count > 0 Then dCont.Add doc.Name, SortDictionaryByKeys(dDoc)
         Next doc
-        If dCont.Count > 0 Then dItems.Add cont.Name, SortDictionaryByKeys(dCont)
+        If dCont.Count > 0 Then m_dItems.Add cont.Name, SortDictionaryByKeys(dCont)
     Next cont
 
     ' Return assembled dictionary
-    Set GetDictionary = dItems
+    Set GetDictionary = m_dItems
 
 End Function
 
@@ -384,7 +390,7 @@ End Function
 '
 Private Function IDbComponent_GetFileList() As Dictionary
     Set IDbComponent_GetFileList = New Dictionary
-    If FSO.FileExists(IDbComponent_SourceFile) Then IDbComponent_GetFileList.Add IDbComponent_SourceFile, vbNullString
+    IDbComponent_GetFileList.Add IDbComponent_SourceFile, vbNullString
 End Function
 
 

--- a/Version Control.accda.src/modules/clsDbDocument.cls
+++ b/Version Control.accda.src/modules/clsDbDocument.cls
@@ -37,11 +37,7 @@ Implements IDbComponent
 Private Sub IDbComponent_Export(Optional strAlternatePath As String)
     Dim strContent As String
     strContent = GetSource
-    If strContent = vbNullString Then
-        If FSO.FileExists(IDbComponent_SourceFile) Then DeleteFile IDbComponent_SourceFile
-    Else
-        WriteFile strContent, Nz2(strAlternatePath, IDbComponent_SourceFile)
-    End If
+    WriteFile strContent, Nz2(strAlternatePath, IDbComponent_SourceFile)
     VCSIndex.Update Me, IIf(strAlternatePath = vbNullString, eatExport, eatAltExport), GetStringHash(strContent, True)
 End Sub
 
@@ -81,8 +77,15 @@ Private Sub IDbComponent_Import(strFile As String)
             For Each varDoc In dCont.Keys
                 Set dDoc = dCont(varDoc)
                 For Each varProp In dDoc.Keys
-                    ' Attempt to add or update the property value on the object.
-                    SetDAOProperty dbs.Containers(varCont).Documents(varDoc), dbText, CStr(varProp), dDoc(varProp)
+                    If TypeOf dDoc(varProp) Is Dictionary Then
+                        ' Attempt to add or update the property value on the object.
+                        Dim dProp As Dictionary
+                        Set dProp = dDoc(varProp)
+                        SetDAOProperty dbs.Containers(varCont).Documents(varDoc), dProp("Type"), CStr(varProp), dProp("Value")
+                    Else
+                        ' Handle the original format
+                        SetDAOProperty dbs.Containers(varCont).Documents(varDoc), dbText, CStr(varProp), dDoc(varProp)
+                    End If
                     CatchAny eelError, "Error setting document property " & varCont & "." & varDoc & "." & varProp, ModuleName(Me)
                 Next varProp
             Next varDoc
@@ -113,10 +116,7 @@ Private Sub IDbComponent_Merge(strFile As String)
     ' Remove any document properties that don't exist in the incoming file,
     ' then import the file.
     Set dFile = ReadJsonFile(strFile)
-    If dFile Is Nothing Then
-        Set dFile = New Dictionary
-        Set dFile("Items") = New Dictionary
-    End If
+    If dFile Is Nothing Then Set dFile = New Dictionary
     RemoveMissing dFile("Items"), GetDictionary
 
     ' Import if file exists
@@ -191,6 +191,7 @@ End Function
 Private Function GetDictionary(Optional blnUseCache As Boolean = True) As Dictionary
 
     Dim prp As DAO.Property
+    Dim dItems As Dictionary    ' All Items
     Dim dCont As Dictionary     ' Container
     Dim dDoc As Dictionary      ' Document
     Dim cont As DAO.Container
@@ -206,7 +207,7 @@ Private Function GetDictionary(Optional blnUseCache As Boolean = True) As Dictio
     End If
 
     ' Create dictionary object to hold all the items
-    Set m_dItems = New Dictionary
+    Set dItems = New Dictionary
     Set dbs = CurrentDb
 
     ' Loop through all the containers, documents, and properties.
@@ -219,34 +220,55 @@ Private Function GetDictionary(Optional blnUseCache As Boolean = True) As Dictio
             Set dDoc = New Dictionary
             For Each prp In doc.Properties
                 blnSave = False
-                If cont.Name = "Databases" And doc.Name = "SummaryInfo" Then
-                    ' Keep most of this information (Blacklist approach)
-                    Select Case prp.Name
-                        Case "AllPermissions", "Container", "DateCreated", "LastUpdated", _
-                            "Name", "Owner", "GUID", "Permissions", "UserName" ' Ignore these
+                If cont.Name = "Databases" Then
+                    Select Case doc.Name
+                        Case "SummaryInfo", "UserDefined"
+                            ' Keep most of this information (Blacklist approach)
+                            Select Case prp.Name
+                                Case "AllPermissions", "Container", "DateCreated", "LastUpdated", _
+                                    "Name", "Owner", "GUID", "Permissions", "UserName" ' Ignore these
+                                Case Else
+                                    blnSave = True
+                            End Select
                         Case Else
-                            blnSave = True
-                    End Select
-                Else
-                    ' For other documents, use the whitelist approach, primarily
-                    ' gathering navigation pane item descriptions and hidden status.
-                    Select Case prp.Name
-                        Case "Description"
-                            blnSave = True
+                            ' For other documents, use the whitelist approach, primarily
+                            ' gathering navigation pane item descriptions and hidden status.
+                            Select Case prp.Name
+                                Case "Description"
+                                    blnSave = True
+                            End Select
                     End Select
                 End If
                 ' Don't save properties on temporary items
                 If Left(doc.Name, 1) = "~" Then blnSave = False
                 ' If save flag set, save the property
-                If blnSave Then dDoc.Add prp.Name, prp.Value
+                If blnSave Then
+                    Dim dProp As Dictionary
+                    Set dProp = New Dictionary
+                    dProp.CompareMode = TextCompare
+
+                    ' NOTE: we are not setting the DDL because we have no way of determining
+                    ' whether a property is a DDL or not. For an .accdb file format, it will
+                    ' always be false. For an .mdb file with ULS enabled, it might matter.
+                    ' Additional programming would be needed to handle such properties but
+                    ' we are not expending the extra effort for this extreme edge case.
+                    ' Also note that DDL and Inherited are two unrelated properties. In
+                    ' practice, we shouldn't include any inherited properties but I do not
+                    ' believe any container/document properties can be inherited. Again,
+                    ' an edge case not worth expending efforts.
+                    dProp.Add "Type", prp.Type
+                    dProp.Add "Value", prp.Value
+
+                    dDoc.Add prp.Name, dProp
+                End If
             Next prp
             If dDoc.Count > 0 Then dCont.Add doc.Name, SortDictionaryByKeys(dDoc)
         Next doc
-        If dCont.Count > 0 Then m_dItems.Add cont.Name, SortDictionaryByKeys(dCont)
+        If dCont.Count > 0 Then dItems.Add cont.Name, SortDictionaryByKeys(dCont)
     Next cont
 
     ' Return assembled dictionary
-    Set GetDictionary = m_dItems
+    Set GetDictionary = dItems
 
 End Function
 
@@ -362,7 +384,7 @@ End Function
 '
 Private Function IDbComponent_GetFileList() As Dictionary
     Set IDbComponent_GetFileList = New Dictionary
-    IDbComponent_GetFileList.Add IDbComponent_SourceFile, vbNullString
+    If FSO.FileExists(IDbComponent_SourceFile) Then IDbComponent_GetFileList.Add IDbComponent_SourceFile, vbNullString
 End Function
 
 

--- a/Version Control.accda.src/modules/clsDbQuery.cls
+++ b/Version Control.accda.src/modules/clsDbQuery.cls
@@ -100,24 +100,63 @@ Private Sub IDbComponent_Import(strFile As String)
     Dim strQueryName As String
     Dim strFileSql As String
     Dim strSql As String
+    Dim blnRecreated As Boolean
 
     ' Only import files with the correct extension.
     If Not strFile Like "*.bas" Then Exit Sub
 
     ' Import query from file
     strQueryName = GetObjectNameFromFileName(strFile)
-    LoadComponentFromText acQuery, strQueryName, strFile
-    Set m_Query = CurrentData.AllQueries(strQueryName)
-    VCSIndex.Update Me, eatImport, GetFileHash(strFile)
+
 
     ' In some cases, such as when a query contains a subquery, AND has been modified in the
     ' visual query designer, it may be imported incorrectly and unable to run. For these
     ' cases we have added an option to overwrite the .SQL property with the SQL that we
     ' saved separately during the export. See the following link for further details:
     ' https://github.com/joyfullservice/msaccess-vcs-addin/issues/76
-
-    ' Check option to import exact query from SQL
+    '
+    ' There are two variants of this problem; we may successfully import a query but
+    ' it's in a broken state OR we may not be able to import the query at all.
+    ' The latter case is handled first, and former further down after the import.
+    '
+    ' However, if we create a new query, we might be actually losing some of the
+    ' properties relating to the visual query designer. Thus, a warning is
+    ' generated to alert of such issue.
     If Options.ForceImportOriginalQuerySQL Then
+        If LoadComponentFromText(acQuery, strQueryName, strFile, True) = False Then
+            ' Replace .bas extension with .sql to get file content
+            strFileSql = Left$(strFile, Len(strFile) - 4) & ".sql"
+
+            ' Tries to get SQL content from the SQL file previously exported
+            strSql = ReadFile(strFileSql)
+
+            ' Update query def with saved SQL
+            If strSql <> vbNullString Then
+                Set dbs = CurrentDb
+                dbs.CreateQueryDef strQueryName, strSql
+                blnRecreated = True
+                Log.Error eelWarning, "  Restored query " & strQueryName & " using SQL. Some visual design properties may be lost.", ModuleName(Me) & ".Import"
+            Else
+                Log.Error eelError, "  Couldn't get original SQL query for " & strQueryName
+                Exit Sub
+            End If
+        Else
+            ' Something went horribly wrong.
+            Exit Sub
+        End If
+    Else
+        If LoadComponentFromText(acQuery, strQueryName, strFile) = False Then
+            ' An error occurred and it has been logged already
+            Exit Sub
+        End If
+    End If
+
+    Set m_Query = CurrentData.AllQueries(strQueryName)
+    VCSIndex.Update Me, eatImport, GetFileHash(strFile)
+
+    ' Check option to import exact query from SQL, unless it was already
+    ' imported as a new query from above.
+    If Options.ForceImportOriginalQuerySQL And (blnRecreated = False) Then
 
         ' Replace .bas extension with .sql to get file content
         strFileSql = Left$(strFile, Len(strFile) - 4) & ".sql"

--- a/Version Control.accda.src/modules/clsPerformance.cls
+++ b/Version Control.accda.src/modules/clsPerformance.cls
@@ -57,7 +57,7 @@ Private Declare PtrSafe Function GetTimeAPI Lib "kernel32" Alias "QueryPerforman
 '
 Public Sub StartTiming()
     If Not Me.Enabled Then Exit Sub
-    Reset
+    Me.Reset
     Set this.Overall = New clsPerformanceItem
     this.Overall.Start = MicroTimer
 End Sub

--- a/Version Control.accda.src/modules/modImportExport.bas
+++ b/Version Control.accda.src/modules/modImportExport.bas
@@ -906,6 +906,10 @@ Public Sub Build(strSourceFolder As String, blnFullBuild As Boolean _
         Perf.OperationEnd
     End If
 
+    ' Reset the LoadFromText state because the path may be now different
+    ' so any cached list of error files may be invalid.
+    modLoadFromText.Reset
+
     ' Start log and performance timers
     Log.Clear
     Log.SourcePath = strSourceFolder

--- a/Version Control.accda.src/modules/modLoadFromText.bas
+++ b/Version Control.accda.src/modules/modLoadFromText.bas
@@ -1,0 +1,147 @@
+﻿Attribute VB_Name = "modLoadFromText"
+'---------------------------------------------------------------------------------------
+' Module    : modLoadFromText
+' Author    : bclothier
+' Date      : 8/26/2025
+' Purpose   : Wraps the Application.LoadFromText method with better error handling
+'---------------------------------------------------------------------------------------
+Option Compare Database
+Option Private Module
+Option Explicit
+
+Private Type udtThis
+    IsInitialized As Boolean
+    FSO As FileSystemObject
+    ErrorFileList As Dictionary
+    LastReadError As String
+End Type
+Private this As udtThis
+
+'---------------------------------------------------------------------------------------
+' Procedure : Reset
+' Author    : bclothier
+' Date      : 8/26/2025
+' Purpose   : Clear the state
+'---------------------------------------------------------------------------------------
+'
+Public Sub Reset(Optional DeleteErrorFiles As Boolean = False)
+    If DeleteErrorFiles Then
+        Dim strErrorFilePath As String
+        Dim strProjectPath
+
+        strProjectPath = ProjectPath
+        If Len(strProjectPath) Then
+            strErrorFilePath = Dir$(BuildPath2(strProjectPath, "errors*.txt"))
+            Do Until Len(strErrorFilePath) = 0
+                Kill BuildPath2(strProjectPath, strErrorFilePath)
+                strErrorFilePath = Dir()
+            Loop
+        End If
+    End If
+
+    Set this.ErrorFileList = New Dictionary
+    this.ErrorFileList.CompareMode = TextCompare
+    this.IsInitialized = True
+End Sub
+
+'---------------------------------------------------------------------------------------
+' Procedure : LoadFromText
+' Author    : bclothier
+' Date      : 8/26/2025
+' Purpose   : Wraps the Application.LoadFromText to return detailed errors.
+'---------------------------------------------------------------------------------------
+'
+Public Sub LoadFromText(ObjectType As AcObjectType, ObjectName As String, FileName As String)
+    On Error GoTo ErrHandler
+
+    If this.IsInitialized = False Then
+        PopulateErrorFileList
+    End If
+
+    Application.LoadFromText ObjectType, ObjectName, FileName
+
+ExitProc:
+    Exit Sub
+
+ErrHandler:
+    If Err.Number = 2128 Then
+        Dim ErrNumberOriginal As Long
+        Dim ErrSourceOriginal As String
+        Dim ErrDescriptionOriginal As String
+        Dim ErrHelpFileOriginal As String
+        Dim ErrHelpContextOriginal As Long
+
+        ErrNumberOriginal = Err.Number
+        ErrSourceOriginal = Err.Source
+        ErrDescriptionOriginal = Err.Description
+        ErrHelpFileOriginal = Err.HelpFile
+        ErrHelpContextOriginal = Err.HelpContext
+
+        ReadErrorFile
+        Err.Raise ErrNumberOriginal, ErrSourceOriginal, ErrDescriptionOriginal & this.LastReadError, ErrHelpFileOriginal, ErrHelpContextOriginal
+    Else
+        Err.Raise Err.Number, Err.Source, Err.Description, Err.HelpFile, Err.HelpContext
+    End If
+    Resume ExitProc
+    Resume ' for debugging
+End Sub
+
+'---------------------------------------------------------------------------------------
+' Procedure : PopulateErrorFileList
+' Author    : bclothier
+' Date      : 8/26/2025
+' Purpose   : Initialize the dictionary and check for pre-existing error files.
+'---------------------------------------------------------------------------------------
+'
+Private Sub PopulateErrorFileList()
+    Set this.ErrorFileList = New Dictionary
+    this.ErrorFileList.CompareMode = TextCompare
+
+    Dim strErrorFilePath As String
+    Dim strProjectPath
+
+    strProjectPath = ProjectPath
+    If Len(strProjectPath) Then
+        strErrorFilePath = Dir$(BuildPath2(strProjectPath, "errors*.txt"))
+        Do Until Len(strErrorFilePath) = 0
+            this.ErrorFileList.Add strErrorFilePath, vbNullString
+            strErrorFilePath = Dir()
+        Loop
+    End If
+    Set this.FSO = FSO
+    this.IsInitialized = True
+End Sub
+
+'---------------------------------------------------------------------------------------
+' Procedure : ReadErrorFile
+' Author    : bclothier
+' Date      : 8/26/2025
+' Purpose   : Locate the latest error file and read the contents
+'---------------------------------------------------------------------------------------
+'
+Private Function ReadErrorFile() As String
+    Dim strErrorFilePath As String
+    Dim strProjectPath
+    Dim txtStream As TextStream
+
+    strProjectPath = ProjectPath
+    If Len(strProjectPath) Then
+        strErrorFilePath = Dir$(BuildPath2(strProjectPath, "errors*.txt"))
+        Do Until Len(strErrorFilePath) = 0
+            If Not this.ErrorFileList.Exists(strErrorFilePath) Then
+                ' It's a new file, so read it.
+                Set txtStream = this.FSO.OpenTextFile(BuildPath2(strProjectPath, strErrorFilePath), ForReading, False)
+                'Skip the first line
+                txtStream.ReadLine
+
+                this.LastReadError = Trim$(txtStream.ReadAll)
+                ' Add to the list so it'll be ignored next time.
+                this.ErrorFileList.Add strErrorFilePath, vbNullString
+
+                ' We can exit early since only one file will be created
+                Exit Do
+            End If
+            strErrorFilePath = Dir()
+        Loop
+    End If
+End Function

--- a/Version Control.accda.src/modules/modVCSUtility.bas
+++ b/Version Control.accda.src/modules/modVCSUtility.bas
@@ -638,7 +638,8 @@ End Function
 '
 Public Function LoadComponentFromText(intType As AcObjectType _
                                     , ByRef strName As String _
-                                    , ByRef strFile As String) As Boolean
+                                    , ByRef strFile As String _
+                                    , Optional blnSuppressError As Boolean = False) As Boolean
 
     Const FunctionName As String = ModuleName & ".LoadComponentFromText"
 
@@ -653,7 +654,7 @@ Public Function LoadComponentFromText(intType As AcObjectType _
 
     LogUnhandledErrors FunctionName
     On Error GoTo ErrHandler
-    Perf.OperationStart "Load Component from Text"
+    Perf.OperationStart FunctionName
 
 RetryImport:
     ' In most cases we are importing/converting the actual source file.
@@ -715,15 +716,15 @@ RetryImport:
             ' Other objects converted to UCS2
             ConvertUtf8Ucs2 strSourceFile, strTempFile, False
         End If
-        Perf.OperationStart "App.LoadFromText()"
-        Application.LoadFromText intType, strName, strTempFile
+        Perf.OperationStart "modLoadFromText.LoadFromText"
+        modLoadFromText.LoadFromText intType, strName, strTempFile
         Perf.OperationEnd
         DeleteFile strTempFile, True
 
     Else
         ' Load UTF-8 file
-        Perf.OperationStart "App.LoadFromText()"
-        Application.LoadFromText intType, strName, strSourceFile
+        Perf.OperationStart "modLoadFromText.LoadFromText"
+        modLoadFromText.LoadFromText intType, strName, strSourceFile
         Perf.OperationEnd
     End If
 
@@ -746,8 +747,19 @@ Exit_Here:
     Exit Function
 
 ErrHandler:
+    Dim strErrDescription As String
+    strErrDescription = Err.Description
+    Err.Clear ' FIXME: A temporary hack to avoid spurious output in logs when calling Log.Error
+
+    If blnSuppressError Then
+        ' Generate warning entries for suppressed errors
+        Log.Error eelWarning, T("Import issue with '{0}'; {1}", var0:=strName, var1:=strErrDescription), FunctionName
+        blnErrInFunction = True
+        Resume CleanUp
+    End If
+
     ' Issue importing form. We need to prompt user to see if we continue on or not.
-    Log.Error eelError, T("Import issue with '{0}'", var0:=strName), FunctionName
+    Log.Error eelError, T("Import issue with '{0}'; {1}", var0:=strName, var1:=strErrDescription), FunctionName
 
     Select Case MsgBox2(T("Could not import '{0}'.", var0:=strName) _
             , T("Abort build, retry importing, or skip?") _
@@ -759,7 +771,7 @@ ErrHandler:
     Case vbAbort
         Log.Error eelCritical, "Aborted build.", FunctionName
         blnErrInFunction = True
-        GoTo CleanUp
+        Resume CleanUp
 
     Case vbRetry
         Log.Add T("Retrying import for: {0}", var0:=strName)


### PR DESCRIPTION
Closes #665

The PR brings the following enhancements:

* Support for the user-defined properties which are stored inside the `UserDefined` document. We already had `clsDbDocument` handling the document properties but there were two problems:
  - It applies a whitelist on all other documents but blacklist for `SummaryInfo` only. Thus, any properties in the `UserDefined` document got lost in the export. 
  - A `UserDefined` property can be any type. The original version supported only the text. This has been updated to support any types with support for the backward compatibility. Updating to this will generate a change in the exported `documents.json`, converting from a simple key-value pair to a key-object to encode both type and value.
* Support for detailed error reporting from `Application.LoadFromText`. Typically, when Access encounters a problem with executing `Application.LoadFromtText`, it will generate a small text file, usually named errors*.txt which provides detailed, typically the specific error and the line the import failed on, which may be helpful in further troubleshooting. 
  - To support this functionality, the `Application.LoadFromText` is now wrapped inside a `modLoadFromText` module. This handles the discovery of any existing `errors*.txt` file and add them to a ignore list and on error 2128, locate the newly created `*errors*.txt` and then read its content and add it to the log.
  - Because `errors*.txt` are text files and could theoretically exist or be created by a different source, we by default will not attempt to delete them. We do provide for this via an optional parameter in the `Reset` method which is currently used and should be an opt-in. 
* Improved support for importing problematic queries. We discovered queries that could not be imported at all despite the fact that they were functional, could be exported without any issues but due to their complexity, fails completely when importing, resulting in a broken build. 
  - Because this is during the import, the Force SQL option does not help since it only operates post-import. 
  - To remedy this, we updated the `clsDbQuery` class to handle both the import and the after-fact import with check in the place for the force SQL. If a query cannot be imported, a new query with same name and SQL will be then recreated which can lead to a loss of the designer properties but at least the build is not broken. A warning will be issued to the log. 