### PR TITLE
Restore old logic for Description property in other Document containers than Databases

### DIFF
--- a/Version Control.accda.src/modules/clsDbDocument.cls
+++ b/Version Control.accda.src/modules/clsDbDocument.cls
@@ -244,6 +244,13 @@ Private Function GetDictionary(Optional blnUseCache As Boolean = True) As Dictio
                                     blnSave = True
                             End Select
                     End Select
+                Else
+                    ' For documents in other containers, use the whitelist approach, primarily
+                    ' gathering navigation pane item descriptions and hidden status.
+                    Select Case prp.Name
+                        Case "Description"
+                            blnSave = True
+                    End Select
                 End If
                 ' Don't save properties on temporary items
                 If Left(doc.Name, 1) = "~" Then blnSave = False


### PR DESCRIPTION
Closes #684.