### PR TITLE
Visual Fix: Reset progress bar between each export category

### DIFF
--- a/Version Control.accda.src/modules/modImportExport.bas
+++ b/Version Control.accda.src/modules/modImportExport.bas
@@ -264,6 +264,7 @@ Public Sub ExportSource(blnFullExport As Boolean, Optional intFilter As eContain
             End If
             'Log.Flush  ' Gives smoother output, but slows down export.
             Perf.CategoryEnd lngCount
+            Log.ProgressBar.Reset
         End If
 
     Next varCatKey
@@ -1160,6 +1161,7 @@ Public Sub Build(strSourceFolder As String, blnFullBuild As Boolean _
             Log.Add "[" & dFiles.Count & "]"
         End If
         Perf.CategoryEnd dFiles.Count
+        Log.ProgressBar.Reset
 
     Next varCategory
 


### PR DESCRIPTION
### Issue
- If the number of files in any previous category was ≥ the number of files in the current category, it would always show 100%.
- Additionally, say the max number of files in any previous category was 25 items and there are 100 items in the current category, the progress bar would start at 25% and then hang at 100% for 25 files.

### Fix
Reset the progress bar between each category for both importing and exporting.