### PR TITLE
Auto-close frmVCSMain in silent mode after build completes

### DIFF
--- a/Version Control.accda.src/forms/frmVCSMain.cls
+++ b/Version Control.accda.src/forms/frmVCSMain.cls
@@ -271,6 +271,11 @@ Public Sub FinishBuild(blnFullBuild As Boolean _
     Me.strLastLogFilePath = Log.LogFilePath
     Me.strCopyToClipboardPath = Log.LogFilePath
 
+    ' Auto-close in silent/unattended mode
+    If Operation.InteractionMode = eimSilent Then
+        cmdClose_Click
+    End If
+
 End Sub
 
 


### PR DESCRIPTION
I'm currently in the process of updating VBA-Build to run with v5, but I was facing a hang in CI because the frmVCSMain was remaining open after build. It's possible to close the it via PowerShell, but I thought it might be simpler to just close it from the addin when running in silent mode.