### PR TITLE
Qualify VBA.GetSetting in modTestAssert so a host project cannot shadow it

### DIFF
--- a/Version Control.accda.src/modules/Tests/modTestAssert.bas
+++ b/Version Control.accda.src/modules/Tests/modTestAssert.bas
@@ -62,7 +62,8 @@ End Sub
 '
 Private Function ResolveAddInPath() As String
     If Len(m_strAddInPath) = 0 Then
-        m_strAddInPath = GetSetting("MSAccessVCS", "Install", "Install Folder", _
+        ' Qualify with VBA. so a host project's own GetSetting cannot shadow the built-in.
+        m_strAddInPath = VBA.GetSetting("MSAccessVCS", "Install", "Install Folder", _
             Environ$("AppData") & "\MSAccessVCS") & "\Version Control"
     End If
     ResolveAddInPath = m_strAddInPath


### PR DESCRIPTION
### Summary

`modTestAssert.ResolveAddInPath` calls `GetSetting(...)` unqualified. Because `modTestAssert` is injected into the **host** database's VBA project to run tests, any host project that defines its own `Public Function GetSetting` shadows the VBA built-in. The built-in takes up to four arguments (`AppName, Section, Key, Default`); a host `GetSetting` with a different signature makes the injected module fail to compile with *"Wrong number of arguments or invalid property assignment,"* which breaks `VCS.RunTests` / `TestAssert` in that database.

### Fix

Qualify the call as `VBA.GetSetting`, so the built-in is always resolved regardless of symbols defined in the host project. One-line change.

### Testing

Reproduced in a production host database that defines its own `GetSetting` function: the test runner failed to compile before the change and compiles/runs cleanly after. No other behavior affected.

### Scope / risk

Test-runner infrastructure only (`modTestAssert.bas`). No functional change to export/import/build.
