### PR TITLE
Guard cIdx against Nothing in component exporters to fix single-object export crash (error 91)

### DIFF
--- a/Version Control.accda.src/modules/Components/clsDbForm.cls
+++ b/Version Control.accda.src/modules/Components/clsDbForm.cls
@@ -78,8 +78,10 @@ Private Sub IDbComponent_Export(Optional strAlternatePath As String)
         strHash, GetCodeModuleHash(IDbComponent_ComponentType, m_Form.Name), _
         strMetaHash:=GetMetadataHash("Forms", m_Form.Name, acForm))
 
-    ' Cache the @Folder annotation in the index
-    cIdx.FolderAnnotation = IIf(Len(strAnnotation) > 0, strAnnotation, FOLDER_ANNOTATION_NONE)
+    ' Cache the @Folder annotation in the index.
+    ' Guard against a Nothing item under an abnormal/re-entrant index state.
+    If Not cIdx Is Nothing Then _
+        cIdx.FolderAnnotation = IIf(Len(strAnnotation) > 0, strAnnotation, FOLDER_ANNOTATION_NONE)
 
 End Sub
 

--- a/Version Control.accda.src/modules/Components/clsDbModule.cls
+++ b/Version Control.accda.src/modules/Components/clsDbModule.cls
@@ -98,7 +98,9 @@ Private Sub IDbComponent_Export(Optional strAlternatePath As String)
 
     ' Cache the @Folder annotation in the index so subsequent scans
     ' can skip the expensive VBE COM call for unchanged objects.
-    cIdx.FolderAnnotation = IIf(Len(strAnnotation) > 0, strAnnotation, FOLDER_ANNOTATION_NONE)
+    ' Guard against a Nothing item under an abnormal/re-entrant index state.
+    If Not cIdx Is Nothing Then _
+        cIdx.FolderAnnotation = IIf(Len(strAnnotation) > 0, strAnnotation, FOLDER_ANNOTATION_NONE)
 
 End Sub
 

--- a/Version Control.accda.src/modules/Components/clsDbReport.cls
+++ b/Version Control.accda.src/modules/Components/clsDbReport.cls
@@ -78,8 +78,10 @@ Private Sub IDbComponent_Export(Optional strAlternatePath As String)
         strHash, GetCodeModuleHash(IDbComponent_ComponentType, m_Report.Name), _
         strMetaHash:=GetMetadataHash("Reports", m_Report.Name, acReport))
 
-    ' Cache the @Folder annotation in the index
-    cIdx.FolderAnnotation = IIf(Len(strAnnotation) > 0, strAnnotation, FOLDER_ANNOTATION_NONE)
+    ' Cache the @Folder annotation in the index.
+    ' Guard against a Nothing item under an abnormal/re-entrant index state.
+    If Not cIdx Is Nothing Then _
+        cIdx.FolderAnnotation = IIf(Len(strAnnotation) > 0, strAnnotation, FOLDER_ANNOTATION_NONE)
 
 End Sub
 

--- a/Version Control.accda.src/modules/Components/clsDbVbeForm.cls
+++ b/Version Control.accda.src/modules/Components/clsDbVbeForm.cls
@@ -107,8 +107,10 @@ Private Sub IDbComponent_Export(Optional strAlternatePath As String)
     Dim cIdx As clsVCSIndexItem
     Set cIdx = VCSIndex.Update(Me, IIf(strAlternatePath = vbNullString, eatExport, eatAltExport), GetStringHash(strContent, True))
 
-    ' Cache the @Folder annotation in the index
-    cIdx.FolderAnnotation = IIf(Len(strAnnotation) > 0, strAnnotation, FOLDER_ANNOTATION_NONE)
+    ' Cache the @Folder annotation in the index.
+    ' Guard against a Nothing item under an abnormal/re-entrant index state.
+    If Not cIdx Is Nothing Then _
+        cIdx.FolderAnnotation = IIf(Len(strAnnotation) > 0, strAnnotation, FOLDER_ANNOTATION_NONE)
 
     ' Remove duplicate files at any other location in the base folder tree
     CleanupDuplicateSourceFiles IDbComponent_BaseFolder, strExportFolder, _


### PR DESCRIPTION
### Summary

`IDbComponent_Export` in `clsDbForm`, `clsDbReport`, `clsDbModule`, and `clsDbVbeForm` sets `cIdx.FolderAnnotation` on the result of `VCSIndex.Update(...)` without checking for `Nothing`. Under an abnormal/re-entrant index state, `Update` can return `Nothing`, so `cIdx.FolderAnnotation` raises **runtime error 91** ("Object variable or With block variable not set"), halting the add-in in break mode.

This reproduces reliably on the **single-object export** path (`ExportObject`) — for example when driving the add-in via the [msaccess-vcs-mcp](https://github.com/joyfullservice/msaccess-vcs-mcp) server's `vcs_export_object` tool, where every single-object module/form/report export crashes.

### Fix

Guard the annotation cache with `If Not cIdx Is Nothing Then` before assigning. When `Update` returns `Nothing`, skipping the annotation cache is a harmless performance fallback: the next scan recomputes the `@Folder` annotation via the VBE COM call. The normal path (non-`Nothing` `cIdx`) is unchanged.

### Testing

Built a local add-in from these changes and re-ran `vcs_export_object` for a single module against a production database:

- **Before:** runtime error 91 at `cIdx.FolderAnnotation`, add-in halts in break mode.
- **After:** `success` with a clean export log — the full hash/sanitize/metadata pipeline runs to completion, the object is exported to the correct `@Folder` subfolder, and the index is updated.

### Scope / risk

Four component exporters; export path only. Purely defensive — no change to normal-path behavior.
