### PR TITLE
Defer silent-mode form close until build completion

### DIFF
--- a/Version Control.accda.src/forms/frmVCSMain.cls
+++ b/Version Control.accda.src/forms/frmVCSMain.cls
@@ -271,9 +271,12 @@ Public Sub FinishBuild(blnFullBuild As Boolean _
     Me.strLastLogFilePath = Log.SavedLogFilePath
     Me.strCopyToClipboardPath = Log.SavedLogFilePath
 
-    ' Auto-close in silent/unattended mode
+    ' Auto-close in silent/unattended mode. Defer via the timer so the close runs
+    ' after modBuild.Build calls Operation.Finish; closing synchronously here unloads
+    ' the form while Operation.Status is still eosRunning, tripping the Form_Unload
+    ' cancel prompt -- a deadlock in an unattended session.
     If Operation.InteractionMode = eimSilent Then
-        cmdClose_Click
+        AutoClose
     End If
 
 End Sub


### PR DESCRIPTION
Fixes a deadlock during silent or unattended build/merge sessions.

`frmVCSMain.FinishBuild` now schedules the existing timer-based `AutoClose` rather than synchronously invoking the close handler while `Operation.Status` is still `eosRunning`. This lets the caller reach `Operation.Finish` before `Form_Unload` evaluates cancellation state.

Validation: `git diff --check`; one-file, 5-line insertion / 2-line removal delta. Access rebuild/compile remains required for runtime validation.