### PR TITLE
feat(UIAutomation): recognize Spanish navigation pane image names

### DIFF
--- a/Version Control.accda.src/modules/Utility/modUIAutomation.bas
+++ b/Version Control.accda.src/modules/Utility/modUIAutomation.bas
@@ -58,7 +58,7 @@ End Function
 ' Author    : Adam Waller
 ' Date      : 2/21/2023
 ' Purpose   : Return the database object from the UI button
-'           : Supported languages: English, German, French, Dutch
+'           : Supported languages: English, German, French, Dutch, Spanish
 '---------------------------------------------------------------------------------------
 '
 Private Function GetUnderlyingDbObjectFromButton(oClient As CUIAutomation, oElement As IUIAutomationElement) As AccessObject
@@ -79,17 +79,17 @@ Private Function GetUnderlyingDbObjectFromButton(oClient As CUIAutomation, oElem
 
     ' Identify the item based on the image name
     ' This sadly depends on the Access language
-    If LikeAny(strImage, "Table*", "*Tabel*") Then
+    If LikeAny(strImage, "Table*", "*Tabel*", "Tabla*") Then
         Set objItem = CurrentData.AllTables(strName)
-    ElseIf LikeAny(strImage, "*Query", "*Abfrage", "Requête*") Then
+    ElseIf LikeAny(strImage, "*Query", "*Abfrage", "Requête*", "Consulta*") Then
         Set objItem = CurrentData.AllQueries(strName)
     ElseIf LikeAny(strImage, "Form*") Then
         Set objItem = CurrentProject.AllForms(strName)
-    ElseIf LikeAny(strImage, "Report", "Rapport", "Bericht", "État") Then
+    ElseIf LikeAny(strImage, "Report", "Rapport", "Bericht", "État", "Informe") Then
         Set objItem = CurrentProject.AllReports(strName)
     ElseIf LikeAny(strImage, "Macro", "Makro") Then
         Set objItem = CurrentProject.AllMacros(strName)
-    ElseIf LikeAny(strImage, "*Modul*") Then ' Module and Class Module
+    ElseIf LikeAny(strImage, "*Modul*", "*Módul*") Then ' Module and Class Module
         Set objItem = CurrentProject.AllModules(strName)
     ElseIf LikeAny(strImage, "Function", "Fonction") Then ' ADP specific project items
         Set objItem = CurrentData.AllFunctions(strName)


### PR DESCRIPTION
`GetUnderlyingDbObjectFromButton` identifies the selected navigation pane item from
its button image name, which Access localizes. Spanish installations report names
that match none of the existing patterns:

| Object type | Spanish image name | Existing patterns |
|---|---|---|
| Table | `Tabla…` | `Table*`, `*Tabel*` |
| Query | `Consulta…` | `*Query`, `*Abfrage`, `Requête*` |
| Report | `Informe` | `Report`, `Rapport`, `Bericht`, `État` |
| Module | `Módulo…` | `*Modul*` — the accented *ó* breaks the substring |

So both Export Selected and Reload Selected reported "Please Select an Object First"
even with an object selected and focused.

Form and macro items need no new pattern: `"Form*"` already covers `Formulario` and
the macro image name is `Macro` in Spanish too. The accented literal is stored exactly
like the existing `Requête` and `État` patterns (UTF-8), so it needs no special
handling on import.

Verified on Access 16.0 32-bit with the Spanish UI.

This is the language addition the code itself invites: *"If you are using a
non-English version of Access and it is still not working, please open an issue on
GitHub to add support for your language."*