### PR TITLE
ci: Add build and release workflows

### DIFF
--- a/.github/workflows/build-addin.yml
+++ b/.github/workflows/build-addin.yml
@@ -31,7 +31,7 @@ jobs:
           source-dir: "./Version Control.accda.src"
           target-dir: "bin"
           vcs-url: "https://api.github.com/repos/joyfullservice/msaccess-vcs-addin/releases/tags/v5.0.1"
-          compile: "true" # enable compile to produce .accde with exposed public API
+          # compile: "true" # enable compile to produce .accde with exposed public API
         timeout-minutes: 10
 
       - name: Upload build artifact

--- a/.github/workflows/build-addin.yml
+++ b/.github/workflows/build-addin.yml
@@ -1,0 +1,42 @@
+name: Build Add-in
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - dev
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: windows-2025
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Access runtime
+        uses: DecimalTurn/setup-vba@797e4a232699a98507cb4411d5bea3697427ad57 # v0.3.0
+        with:
+          office-apps: Access
+
+      - name: Build from source
+        id: build
+        uses: AccessCodeLib/msaccess-vcs-build@da38fda0d878d93cf8be66846da0084d27ea97f1 # v1.1.0
+        with:
+          source-dir: "./Version Control.accda.src"
+          target-dir: "bin"
+          vcs-url: "https://api.github.com/repos/joyfullservice/msaccess-vcs-addin/releases/tags/v5.0.1"
+          compile: "true" # enable compile to produce .accde with exposed public API
+        timeout-minutes: 10
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: Version_Control
+          path: "./bin/*"
+          if-no-files-found: error

--- a/.github/workflows/release-addin.yml
+++ b/.github/workflows/release-addin.yml
@@ -67,5 +67,4 @@ jobs:
       - name: Attest build provenance
         uses: actions/attest-build-provenance@v4
         with:
-          subject-name: "${{ env.ZIP_NAME }}"
-          subject-digest: "${{ steps.hash.outputs.digest }}"
+          subject-path: "${{ env.ZIP_NAME }}"

--- a/.github/workflows/release-addin.yml
+++ b/.github/workflows/release-addin.yml
@@ -33,7 +33,7 @@ jobs:
           source-dir: "./Version Control.accda.src"
           target-dir: "bin"
           vcs-url: "https://api.github.com/repos/joyfullservice/msaccess-vcs-addin/releases/tags/v5.0.1"
-          compile: "true" # enable compile to produce .accde with exposed public API
+          # compile: "true" # enable compile to produce .accde with exposed public API
         timeout-minutes: 10
 
       - name: Create versioned ZIP

--- a/.github/workflows/release-addin.yml
+++ b/.github/workflows/release-addin.yml
@@ -40,6 +40,11 @@ jobs:
         shell: pwsh
         run: |
           $zipName = "Version_Control_${{ github.event.release.tag_name }}.zip"
+          $releaseTag = $env:GITHUB_REF_NAME
+          if ($releaseTag -notmatch '^[A-Za-z0-9._-]+$') {
+            throw "Release tag contains unsupported filename characters."
+          }
+          $zipName = "Version_Control_${releaseTag}.zip"
           Compress-Archive -Path .\bin\* -DestinationPath $zipName
           echo "ZIP_NAME=$zipName" | Out-File -FilePath $env:GITHUB_ENV -Append
 

--- a/.github/workflows/release-addin.yml
+++ b/.github/workflows/release-addin.yml
@@ -1,0 +1,66 @@
+name: Release Add-in
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
+jobs:
+  build-and-release:
+    runs-on: windows-2025
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Setup Access runtime
+        uses: DecimalTurn/setup-vba@797e4a232699a98507cb4411d5bea3697427ad57 # v0.3.0
+        with:
+          office-apps: Access
+          install-office: true
+
+      - name: Build accda from source
+        id: build
+        uses: AccessCodeLib/msaccess-vcs-build@da38fda0d878d93cf8be66846da0084d27ea97f1 # v1.1.0
+        with:
+          source-dir: "./Version Control.accda.src"
+          target-dir: "bin"
+          vcs-url: "https://api.github.com/repos/joyfullservice/msaccess-vcs-addin/releases/tags/v5.0.1"
+          compile: "true" # enable compile to produce .accde with exposed public API
+        timeout-minutes: 10
+
+      - name: Create versioned ZIP
+        shell: pwsh
+        run: |
+          $zipName = "Version_Control_${{ github.event.release.tag_name }}.zip"
+          Compress-Archive -Path .\bin\* -DestinationPath $zipName
+          echo "ZIP_NAME=$zipName" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Upload ZIP to release
+        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
+        with:
+          files: ${{ env.ZIP_NAME }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Calculate SHA256
+        id: hash
+        shell: pwsh
+        run: |
+          $hash = Get-FileHash -Algorithm SHA256 -Path "${{ env.ZIP_NAME }}"
+          $digest = "sha256:$($hash.Hash.ToLower())"
+          echo "ZIP_DIGEST=$digest" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "digest=$digest" >> $env:GITHUB_OUTPUT
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: "${{ env.ZIP_NAME }}"
+          subject-digest: "${{ steps.hash.outputs.digest }}"


### PR DESCRIPTION
This PR introduces two new GitHub Actions workflows:
- `build-addin.yml`: Automates the process of building the current version of the addin using a previous version of the addin.
- `release-addin.yml`: Does the same as build-addin.yml, but runs after a release and appends the zipped addin to the release.

Here's an example run of build-addin on my fork: https://github.com/DecimalTurn/msaccess-vcs-addin/actions/runs/32608305358

The build workflow is set to run on each push to `dev` and `main`, so that it can catch any issues on the dev branch. Obviously, the build succeeding doesn't say that much and this workflow would need to be improved to include running the tests in order to actually catch potential regressions, but this can be added in a seperate PR.

The inclusion of the release-addin workflow is entirely optional, but I thought this could still be something useful. Furthermore, if modified to use on the dev branch in order to help create pre-releases for beta-testers.

Note that this PR had to be made against the `main` branch because GitHub doesn't register new workflows until they've been added to the default branch. Once this is merged, the `main` branch would have to be merged into the `dev` branch for the build workflow to take effect when news commits are made on the `dev` branch.

Thanks again to @josef-poetzl for the work on msaccess-vcs-build which powers those workflows.