### PR TITLE
fix: Tab Control has no ControlTip property

### DIFF
--- a/Version Control.accda.src/modules/Infrastructure/clsTranslation.cls
+++ b/Version Control.accda.src/modules/Infrastructure/clsTranslation.cls
@@ -230,7 +230,7 @@ Private Sub ApplyToControlTip(ctl As Control, strReference As String, dReference
 
     ' Decorative control types carry no tooltip.
     Select Case ctl.ControlType
-        Case acLabel, acLine, acRectangle, acPageBreak
+        Case acLabel, acLine, acRectangle, acPageBreak, acTabCtl
             Exit Sub
     End Select
 


### PR DESCRIPTION
A minor change, only really an issue if you open the add-in (install form) with Error Trapping set to 0.