### PR TITLE
fix(tables): detect system tables by attribute instead of name prefix

### DIFF
--- a/Version Control.accda.src/modules/Components/clsDbHiddenAttribute.cls
+++ b/Version Control.accda.src/modules/Components/clsDbHiddenAttribute.cls
@@ -219,6 +219,7 @@ Public Function GetDictionary(Optional blnUseCache As Boolean = True) As Diction
     Dim dbs As Database
     Dim contType As AcObjectType
     Dim colItems As Collection
+    Dim dSysTables As Dictionary
 
     ' Check cache parameter
     If blnUseCache And Not m_dItems Is Nothing Then
@@ -243,6 +244,7 @@ Public Function GetDictionary(Optional blnUseCache As Boolean = True) As Diction
     If DebugMode(True) Then On Error GoTo 0 Else On Error Resume Next
 
     ' Legacy path: Loop through all the containers, documents, and check hidden property
+    Set dSysTables = GetSystemTableNames
     For Each cont In dbs.Containers
         Set dCont = New Dictionary
         Set colItems = New Collection
@@ -250,7 +252,7 @@ Public Function GetDictionary(Optional blnUseCache As Boolean = True) As Diction
         For Each doc In cont.Documents
             If contType <> acDefault Then
                 If Left(doc.Name, 1) <> "~" Then
-                    If Not (contType = acTable And (doc.Name Like "MSys*")) Then
+                    If Not (contType = acTable And dSysTables.Exists(doc.Name)) Then
                         ' Check Hidden Attribute property (only exposed here)
                         If Application.GetHiddenAttribute(contType, doc.Name) Then
                             ' Add to collection of hidden item item names of this type.
@@ -287,10 +289,12 @@ Private Sub RemoveMissing(dMaster As Dictionary, dTarget As Dictionary)
     Dim varDoc As Variant
     Dim strDoc As String
     Dim blnRemove As Boolean
+    Dim dSysTables As Dictionary
 
     ' Go through target dictionary, removing the flag that doesn't exist
     ' in the master dictionary.
     Set dbs = SharedDb
+    Set dSysTables = GetSystemTableNames
     For Each varCont In dTarget.Keys
         Set colItems = dTarget(varCont)
         contType = GetObjectTypeFromContainer(dbs.Containers(varCont))
@@ -298,7 +302,7 @@ Private Sub RemoveMissing(dMaster As Dictionary, dTarget As Dictionary)
             strDoc = CStr(varDoc)
             If contType <> acDefault _
                 And Not (contType = acTable _
-                And (strDoc Like "MSys*" Or strDoc Like "~*")) Then
+                And (dSysTables.Exists(strDoc) Or strDoc Like "~*")) Then
                     ' Check the master dictionary (incoming file) for a match
                     ' Set flag to remove unless we find a match
                     blnRemove = True

--- a/Version Control.accda.src/modules/Components/clsDbTableDataMacro.cls
+++ b/Version Control.accda.src/modules/Components/clsDbTableDataMacro.cls
@@ -146,6 +146,7 @@ Private Function IDbComponent_GetAllFromDB(Optional blnModifiedOnly As Boolean =
     Dim blnNeedAll As Boolean
     Dim sngStart As Single
     Dim lngScanCount As Long
+    Dim dSysTables As Dictionary
 
     ' Build collection if not already cached
     If m_Items(blnModifiedOnly) Is Nothing Then
@@ -157,9 +158,10 @@ Private Function IDbComponent_GetAllFromDB(Optional blnModifiedOnly As Boolean =
             lngScanCount = dbs.TableDefs.Count
             sngStart = Timer
         End If
+        Set dSysTables = GetSystemTableNames
         For Each tdf In dbs.TableDefs
             ' Skip system, temp, and linked tables
-            If Left$(tdf.Name, 4) <> "MSys" Then
+            If Not dSysTables.Exists(tdf.Name) Then
                 If Left$(tdf.Name, 1) <> "~" Then
                     If Len(tdf.Connect) = 0 Then
                         ' Check to see if the table has a data macro

--- a/Version Control.accda.src/modules/Components/clsDbTableDef.cls
+++ b/Version Control.accda.src/modules/Components/clsDbTableDef.cls
@@ -1384,6 +1384,7 @@ Private Function IDbComponent_GetAllFromDB(Optional blnModifiedOnly As Boolean =
     Dim blnNeedAll As Boolean
     Dim sngStart As Single
     Dim lngScanCount As Long
+    Dim dSysTables As Dictionary
 
     ' Build collection if not already cached
     If m_Items(blnModifiedOnly) Is Nothing Then
@@ -1397,8 +1398,9 @@ Private Function IDbComponent_GetAllFromDB(Optional blnModifiedOnly As Boolean =
         ' Batch-load table Types from MSysObjects once, so per-table SourceFile /
         ' IsLinkedTable checks avoid hundreds of slow single-row Type lookups.
         BuildTableTypeCache
+        Set dSysTables = GetSystemTableNames
         For Each tdf In CurrentData.AllTables
-            If tdf.Name Like "MSys*" Or tdf.Name Like "~*" Then
+            If dSysTables.Exists(tdf.Name) Or tdf.Name Like "~*" Then
                 ' Skip system and temporary tables
             Else
                 Set cTable = New clsDbTableDef

--- a/Version Control.accda.src/modules/Tests/Components/modTestTableDef.bas
+++ b/Version Control.accda.src/modules/Tests/Components/modTestTableDef.bas
@@ -18,6 +18,7 @@ Private Const TEST_TABLE_OUTSIDE_EXPORT As String = "vcs_test_td_outside_export"
 Private Const TEST_TABLE_DECIMAL_SQL As String = "vcs_test_decimal_sql"
 Private Const TEST_TABLE_DECIMAL_DAO As String = "vcs_test_decimal_dao"
 Private Const TEST_TABLE_HIDDEN_SIDECAR As String = "vcs_test_hidden_sidecar"
+Private Const TEST_TABLE_SYSTEM_PREFIX As String = "MSysVcsTestUserTable"
 
 
 '---------------------------------------------------------------------------------------
@@ -626,6 +627,62 @@ Public Sub TestHiddenLocalTableKeepsMetadataSidecar()
     DropTestTable TEST_TABLE_HIDDEN_SIDECAR
 
 End Sub
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : TestUserTableWithSystemPrefixIsExported
+' Author    : Ricardo Hernandez (Notarnet)
+' Date      : 9/1/2026
+' Purpose   : A user table whose name begins with MSys must be enumerated for export.
+'           : The prefix is not reserved, and DAO creates such a table with no system
+'           : attribute, which makes it indistinguishable from any other user table.
+'           : Checked in both directions on purpose: the engine's own tables must stay
+'           : out, so that fixing the omission does not start exporting them instead.
+'---------------------------------------------------------------------------------------
+'
+Public Sub TestUserTableWithSystemPrefixIsExported()
+    '@Tag("integration")
+
+    Dim dbs As DAO.Database
+    Dim tdf As DAO.TableDef
+    Dim cCategory As IDbComponent
+    Dim cItem As IDbComponent
+    Dim dAllTables As Dictionary
+    Dim varItem As Variant
+    Dim blnFound As Boolean
+    Dim blnSystemLeaked As Boolean
+    Dim blnNoSystemAttribute As Boolean
+
+    DropTestTable TEST_TABLE_SYSTEM_PREFIX
+
+    Set dbs = CurrentDb
+    Set tdf = dbs.CreateTableDef(TEST_TABLE_SYSTEM_PREFIX)
+    tdf.Fields.Append tdf.CreateField("ID", dbLong)
+    dbs.TableDefs.Append tdf
+    RefreshTableCollections dbs
+
+    ' The premise of the fix: the prefix carries no attribute of its own.
+    ' Assign the comparison first: a Sub call whose first argument opens with a
+    ' parenthesis does not compile in VBA.
+    blnNoSystemAttribute = ((dbs.TableDefs(TEST_TABLE_SYSTEM_PREFIX).Attributes And dbSystemObject) = 0)
+    TestAssert blnNoSystemAttribute, "a user table named MSys* carries no system attribute"
+
+    ' Access GetAllFromDB through the IDbComponent interface (same pattern as modExport)
+    Set cCategory = New clsDbTableDef
+    Set dAllTables = cCategory.GetAllFromDB(False)
+    For Each varItem In dAllTables.Items
+        Set cItem = varItem
+        If cItem.Name = TEST_TABLE_SYSTEM_PREFIX Then blnFound = True
+        If cItem.Name = "MSysObjects" Then blnSystemLeaked = True
+    Next varItem
+
+    TestAssert blnFound, "user table named MSys* should be enumerated for export"
+    TestAssert Not blnSystemLeaked, "engine system tables should stay excluded"
+
+    DropTestTable TEST_TABLE_SYSTEM_PREFIX
+
+End Sub
+
 
 '---------------------------------------------------------------------------------------
 ' Procedure : DropTestTable

--- a/Version Control.accda.src/modules/Tests/Core/modTestConflicts.bas
+++ b/Version Control.accda.src/modules/Tests/Core/modTestConflicts.bas
@@ -146,9 +146,11 @@ Public Sub TestTableDefSourceFile_ResetsLinkTypeCache()
     Dim strLinkedFile As String
     Dim strLocalName As String
     Dim strLinkedName As String
+    Dim dSysTables As Dictionary
 
+    Set dSysTables = GetSystemTableNames
     For Each tdf In CurrentData.AllTables
-        If tdf.Name Like "MSys*" Or tdf.Name Like "~*" Then
+        If dSysTables.Exists(tdf.Name) Or tdf.Name Like "~*" Then
             ' Skip system tables
         Else
             Set cTable = New clsDbTableDef

--- a/Version Control.accda.src/modules/Utility/modDatabase.bas
+++ b/Version Control.accda.src/modules/Utility/modDatabase.bas
@@ -1035,6 +1035,67 @@ End Function
 
 
 '---------------------------------------------------------------------------------------
+' Procedure : GetSystemTableNames
+' Author    : Ricardo Hernandez (Notarnet)
+' Date      : 8/21/2026
+' Purpose   : Return the set of table names that belong to the database engine or to
+'           : Access itself, and should therefore be left out of version control.
+'           : The system attribute set by the engine is used instead of the object
+'           : name, so that user tables which happen to carry the MSys prefix are
+'           : exported as regular tables.
+'           : dbSystemObject (&H80000002) matches both the engine tables (&H80000000:
+'           : MSysObjects, MSysQueries, MSysACEs, MSysRelationships) and the tables
+'           : owned by Access (&H00000002: MSysIMEXSpecs, MSysIMEXColumns,
+'           : MSysNavPaneGroups, MSysAccessStorage, MSysResources), while user tables
+'           : report 0 and linked tables report dbAttachedTable (&H40000000).
+'           : Read once per scan so that callers can test names inside their loop
+'           : without a lookup per object. Reading the attribute does not open a
+'           : linked back-end.
+'---------------------------------------------------------------------------------------
+'
+Public Function GetSystemTableNames() As Dictionary
+
+    Dim dSysTables As Dictionary
+    Dim tdf As DAO.TableDef
+
+    If DebugMode(True) Then On Error GoTo 0 Else On Error Resume Next
+
+    Set dSysTables = New Dictionary
+    dSysTables.CompareMode = TextCompare
+
+    For Each tdf In SharedDb.TableDefs
+        If (tdf.Attributes And dbSystemObject) <> 0 Then
+            dSysTables.Add tdf.Name, True
+            ' A user table can carry the system attribute: hiding implementation tables
+            ' that way is an old Access idiom. Such a table was exported while the filter
+            ' went by name, and is excluded now, so warn instead of dropping it in
+            ' silence. This matters because the orphaned-file cleanup deletes its source
+            ' file in the same pass.
+            If Not (tdf.Name Like "MSys*") Then
+                Log.Error eelWarning, T("Table '{0}' carries the system attribute and is " & _
+                    "excluded from version control.", var0:=tdf.Name), _
+                    ModuleName & ".GetSystemTableNames"
+            End If
+        End If
+    Next tdf
+
+    ' Tables created by the engine that carry no system attribute, and so have to be
+    ' listed by name. (MSysCompactError is left behind by a failed compact operation.)
+    ' Listing a name that does not exist in this database is harmless.
+    If Not dSysTables.Exists("MSysCompactError") Then dSysTables.Add "MSysCompactError", True
+
+    ' A partial set (the handler above covers the whole loop) is detectable afterwards.
+    Log.Add "System tables: " & dSysTables.Count, Options.ShowDebug
+
+    Set GetSystemTableNames = dSysTables
+
+    CatchAny eelError, T("Error reading the list of system tables"), ModuleName & ".GetSystemTableNames"
+
+End Function
+
+
+
+'---------------------------------------------------------------------------------------
 ' Procedure : TableIndexesAvailable
 ' Author    : Adam Waller
 ' Date      : 7/27/2026
@@ -1668,6 +1729,7 @@ Public Sub BuildTableTypeCache()
     Dim dbs As Database
     Dim rst As DAO.Recordset
     Dim strName As String
+    Dim dSysTables As Dictionary
 
     Perf.OperationStart "Build Table Type Cache"
 
@@ -1677,6 +1739,7 @@ Public Sub BuildTableTypeCache()
     If DebugMode(True) Then On Error GoTo Err_Handler Else On Error Resume Next
 
     Set dbs = SharedDb
+    Set dSysTables = GetSystemTableNames
     Set rst = dbs.OpenRecordset( _
         "SELECT Name, Type FROM MSysObjects WHERE Type IN (1,4,6)", _
         dbOpenSnapshot, dbReadOnly)
@@ -1685,7 +1748,7 @@ Public Sub BuildTableTypeCache()
     Do While Not rst.EOF
         strName = Nz(rst!Name, vbNullString)
         If Len(strName) > 0 Then
-            If Not (strName Like "MSys*" Or strName Like "~*") Then
+            If Not (dSysTables.Exists(strName) Or strName Like "~*") Then
                 m_dTableTypeCache(strName) = Nz(rst!Type, 1)
             End If
         End If


### PR DESCRIPTION
Fixes #759.

### The problem

Tables are excluded from version control by testing whether their name starts with `MSys`,
in six places. The prefix is not reserved, so any table in the user's application that uses
it is silently dropped from the export.

The failure is quiet in the best case and confusing in the worst:

- **Linked tables just vanish.** No `.json` is written under `tbldefs`, so there is nothing
  to link on the way back, and nothing is logged.
- **Local tables break the build.** `clsDbTableData` has no name filter of its own — it
  enumerates `CurrentData.AllTables` and only consults `TablesToExportData`. The *data* of
  such a table is therefore exported while its *definition* is not, and *Build From Source*
  then fails with:

      Table structure not found for 'MSysFoo'.

  (`clsDbTableData.cls:626` and `:683`, in `Import`.)

That last one is the reason this is worth fixing regardless of how unusual the naming
convention is: the export reports success, and the failure only shows up later, on the
rebuild, pointing at a table the user never sees mentioned anywhere else.

### How much is at stake

This is not a corner case invented to justify the report. In the application where we hit it,
three databases rebuilt from source carry 47, 62 and 62 tables using the prefix, out of 477,
567 and 570 tables respectively. In the worst of them that is 62 product tables — roughly one
in nine — missing from the export, while the export itself reports success.

### Why the name is the wrong test

Measured with DAO 12.0 on Access 16.0 32-bit: `CreateTableDef` accepts `MSysMyTable`,
`MsysMixedCase` and `MSYSUpperCase`, and all three come back with `Attributes = 0` — that
is, indistinguishable from any other user table. Only `MSysObjects` is refused, and with
error 3010 ("already exists"), not because of the prefix.

The engine already marks its own objects. `dbSystemObject` is `&H80000002`: the engine sets
the high bit on its four tables (`MSysObjects`, `MSysQueries`, `MSysACEs`,
`MSysRelationships`) and Access sets the low one on the tables it owns (`MSysIMEXSpecs`,
`MSysIMEXColumns`, `MSysNavPaneGroups`, `MSysAccessStorage`, `MSysResources`). No system
table carries both, so the test has to be `<> 0` — written as an equality it matches none of
them.

### The change

A single `GetSystemTableNames` in `modDatabase`, read once per scan so callers can test
names inside their loop without a per-object lookup, replacing the prefix test at the six
sites: `clsDbTableDef`, `clsDbTableDataMacro`, `clsDbHiddenAttribute` (twice),
`modDatabase.BuildTableTypeCache` and `modTestConflicts`.

`MSysCompactError` is added by name: it is left behind by a failed compact and carries no
system attribute.

### One behaviour change worth flagging

Hiding an implementation table by setting the system attribute on it is an old Access idiom.
A table doing that was *exported* while the filter went by name, and is *excluded* now. I
think excluding it is the correct reading of the attribute, but it is a real change in the
other direction, and a silent one would be bad here — the orphaned-file cleanup would delete
its source file in the same pass. So that case logs a warning naming the table.

If you would rather keep those exported, the alternative is to test only the engine bit
(`&H80000000`) plus a list of the Access-owned names. Happy to change it.

### Testing

`TestUserTableWithSystemPrefixIsExported` in `modTestTableDef`: creates the table through
DAO, asserts it carries no system attribute, then walks `clsDbTableDef.GetAllFromDB` through
the `IDbComponent` interface and asserts the table is there — and that `MSysObjects` is not,
so the test cannot be satisfied by exporting the engine tables instead.

Verified in two separate builds. On `dev` with the test but without the fix, the run fails on
`user table named MSys* should be enumerated for export` and on that assertion only: the other two
pass, so the premise holds without the change and the engine tables were already excluded before
it. With the fix applied the suite is green — 464 passed, 5 empty, 0 failures, 2,243 assertions.

To reproduce by hand: create a local table named `MSysFoo` with one field, export the
project, and note that no `tbldefs\MSysFoo.xml` is written and nothing is logged. Add it to
`TablesToExportData` and build from source to get the error above.