### PR TITLE
fix(worker): return the accessibility probe result through a file

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -83,6 +83,58 @@ contradictory guidance.
 
 ---
 
+## 2026-09-07 — Accessibility probe returns through a per-job result file
+
+**Trigger**: `CheckDatabaseAccessible` is the one worker action whose only
+return path was the COM callback, and that path is unavailable in the
+situation the probe exists to measure. Attaching via `GetObject` fails for
+an `.accda` host (error 432) and can take twenty seconds even when it
+works. A worker that launched and died left `WaitForQueue` to time out and
+the caller reading Empty as if it were a measured "not accessible".
+
+**Options explored**:
+- **Keep the COM callback and attach anyway.** Rejected. The attach is taken
+  out only to speak, and it is the one that cannot succeed for an add-in
+  path.
+- **Registry value (`SaveSetting` / `WshShell.RegWrite`).** Rejected. HKCU
+  `Software` is shared across WOW64 views, but the value is a global name,
+  awkward to enumerate or age-clean, and turns application settings into
+  IPC. Same-user ACL is no stronger than a file in `%AppData%`.
+- **Stdout / `WshShell.Exec`.** Deferred. `Exec` shows a console window;
+  worker exit codes are 0 even after an uncaught 424. Not worth a new
+  launch path for a one-token answer.
+- **Nonce-named result file, polled in `WaitForQueue` (chosen).** Same
+  primitive as `rebuild-status.json`, but a short-lived synchronous
+  channel: the parent already waits on a 100 ms in-process loop and
+  returns as soon as the token appears. The delayed-completion problems
+  of rebuild status came from *agent-side* timers and stale identity, not
+  from writing a file.
+
+**Decision**: Reserve a per-launch path with process id plus exclusive
+`CreateTextFile`, pass it as the worker argument, and write `1` / `0` /
+`U`. Result metadata lives on `clsJob` so a reentrant call cannot overwrite
+another job's file. `IsDatabaseAccessible` returns `Empty` for unknown;
+`DatabaseAccessibleToOtherClients` logs (only while the worker is enabled)
+and collapses to `False`. All three build callers stay conservative.
+Timeout, disable, and uninstall expire the job and delete its file so a
+late write cannot complete a later operation. Reads use a Perf-safe
+stream; only file observation is retried.
+
+**What this rules out**: Treating this file as another durable status
+workflow or asking agents to poll it. Switching the probe to a registry
+key. Letting `clsWorker` collapse unknown to `False`. Proceeding with an
+in-place merge when the answer is unknown.
+
+**Relevant files**:
+- `Version Control.accda.src/modules/Integration/clsWorker.cls`
+- `Version Control.accda.src/modules/Infrastructure/clsJob.cls`
+- `Version Control.accda.src/modules/Core/modBuild.bas`
+- `Version Control.accda.src/modules/Tests/Infrastructure/modTestWorkerResult.bas`
+- `Version Control.accda.src/modules/Tests/Infrastructure/clsTestWorkerLifecycle.cls`
+- `docs/architecture.md`
+
+---
+
 ## 2026-08-31 — Form/report code-behind uses full VBAProjectDate fast path
 
 **Trigger**: Fast Save skipped forms and reports when only the code module changed
@@ -6076,6 +6128,11 @@ Changes made: (1) Removed "Encoding", "REQUIRED: Restore BOM After Every Edit", 
 ---
 
 ## 2026-04-02 — Out-of-process worker probe for post-build database lock
+
+> **⚠ Partially superseded** (2026-09-07): the probe still exists and still
+> uses an out-of-process DAO engine, but the result no longer returns through
+> the COM callback / `m_varLastResult`. See "Accessibility probe returns
+> through a per-job result file" above.
 
 **Trigger**: After a build or merge, external clients (MCP tools, ODBC connections) receive JET/ACE error 3734: "The database has been placed in a state by user 'Admin' on machine '...' that prevents it from being opened or locked." The database is unusable to other clients until manually closed and reopened in Access. This blocks automated workflows that query the database immediately after a build.
 

--- a/Version Control.accda.src/modules/Core/modBuild.bas
+++ b/Version Control.accda.src/modules/Core/modBuild.bas
@@ -906,19 +906,29 @@ End Sub
 '           : assume they cannot when there is no way to find out.
 '           :
 '           : The JET/ACE engine does not expose this lock state to same-process callers,
-'           : so the only reliable test is the out-of-process worker probe. When the user
-'           : has disabled the helper script (#727) no probe is possible, and every caller
-'           : here treats "not accessible" as the safe answer: the post-build check
-'           : reopens in shared mode, and the in-place merge falls back to the reopen path
-'           : it used before the probe existed. Returning False without launching anything
-'           : states that intent, rather than leaving it to depend on a skipped worker job
-'           : yielding an empty result.
+'           : so the only reliable test is the out-of-process worker probe. That probe
+'           : returns Empty for unknown. This is the policy boundary that collapses
+'           : unknown to False: the post-build check reopens in shared mode, and the
+'           : in-place merge falls back to the reopen path it used before the probe
+'           : existed. When the helper script is disabled (#727) nothing is launched
+'           : and the warning is skipped; an enabled worker that returns Empty logs
+'           : the warning here rather than in clsWorker.
 '---------------------------------------------------------------------------------------
 '
 Private Function DatabaseAccessibleToOtherClients() As Boolean
-    If modInstall.UseWorkerScript Then
-        DatabaseAccessibleToOtherClients = Worker.IsDatabaseAccessible
+
+    Dim varResult As Variant
+
+    If Not modInstall.UseWorkerScript Then Exit Function
+
+    varResult = Worker.IsDatabaseAccessible
+    If IsEmpty(varResult) Then
+        Log.Error eelWarning, T("No result from the worker. Assuming the database is not accessible to other clients."), _
+            ModuleName & ".DatabaseAccessibleToOtherClients"
+        Exit Function
     End If
+    DatabaseAccessibleToOtherClients = Worker.AccessibilityFromProbeResult(varResult)
+
 End Function
 
 

--- a/Version Control.accda.src/modules/Infrastructure/clsJob.cls
+++ b/Version Control.accda.src/modules/Infrastructure/clsJob.cls
@@ -15,3 +15,11 @@ Public KeyHash As String
 Public Action As String
 Public Start As Double
 Public Timeout As Double
+
+' File-channel jobs keep their own result path so a reentrant launch cannot
+' overwrite another job's handoff. Result survives queue removal because the
+' caller holds this object. ResultExpired marks a timed-out or abandoned job
+' so a late write is discarded instead of completing a later operation.
+Public ResultFile As String
+Public Result As Variant
+Public ResultExpired As Boolean

--- a/Version Control.accda.src/modules/Integration/clsWorker.cls
+++ b/Version Control.accda.src/modules/Integration/clsWorker.cls
@@ -36,6 +36,12 @@ Public Queue As Dictionary
 ' Last result returned by a worker callback
 Private m_varLastResult As Variant
 
+' Result file and queue key of the job reporting through the file channel, if any. One
+' field each for the same reason m_varLastResult is one field: only one job at a time can
+' be waited on for a value, and the duplicate-job guard in CallWorker keeps it that way.
+Private m_strResultFile As String
+Private m_strResultKey As String
+
 ' Generic placeholder objects so we can compile the VBScript in the VBA IDE
 Private WScript As Object
 
@@ -98,10 +104,32 @@ End Function
 '---------------------------------------------------------------------------------------
 '
 Public Function IsDatabaseAccessible() As Boolean
+
+    ' This action reports through a file instead of the callback. It is the only one that
+    ' does not need the Access instance to do its work -- it builds its own DAO engine --
+    ' so attaching would be a dependency taken out purely in order to answer, and that is
+    ' the attach that cannot succeed when the caller's current database is the add-in
+    ' itself. See the 2026-08-12 entry in DECISIONS.md for the measured 432.
     m_varLastResult = Empty
-    CallWorker "DbAccessCheck", 10, "CheckDatabaseAccessible"
+    m_strResultKey = JobKeyHash("DbAccessCheck", "CheckDatabaseAccessible")
+    m_strResultFile = JobResultFile("CheckDatabaseAccessible")
+    CallWorker "DbAccessCheck", 10, "CheckDatabaseAccessible", """" & m_strResultFile & """"
     Me.WaitForQueue 10, "CheckDatabaseAccessible", 0.1
-    IsDatabaseAccessible = CBool(m_varLastResult)
+
+    ' Three outcomes, not two. No file at all means the worker never answered, which is
+    ' not the same as an answer of "not accessible" even though the caller takes the same
+    ' conservative action either way. Stay quiet when the helper script is switched off
+    ' (#727): there an empty result is the documented behaviour, not a fault.
+    If IsEmpty(m_varLastResult) Then
+        If modInstall.UseWorkerScript Then
+            Log.Error eelWarning, T("No result from the worker. Assuming the database is not accessible to other clients."), _
+                ModuleName(Me) & ".IsDatabaseAccessible"
+        End If
+        IsDatabaseAccessible = False
+    Else
+        IsDatabaseAccessible = CBool(m_varLastResult)
+    End If
+
 End Function
 
 
@@ -202,6 +230,10 @@ Public Sub WaitForQueue(dblTimeout As Double, Optional strAction As String = "Al
             DoEvents
         Loop
         DoEvents
+
+        ' Pick up a result delivered through the file channel. An action that does not
+        ' attach has no callback to make, so nothing arrives here on its own.
+        PollJobResults
 
         ' We can exit early if there is nothing in the queue
         If Me.Queue.Count = 0 Then Exit Do
@@ -395,7 +427,7 @@ Private Function CallWorker(strKey As String, dblTimeoutSeconds As Double, _
     End If
 
     ' Make sure this key/action is not already running
-    strHash = GetStringHash(strKey & strAction)
+    strHash = JobKeyHash(strKey, strAction)
     If Me.Queue.Exists(strHash) Then
         Log.Error eelError, "Duplicate job in queue: " & strAction & "." & strKey, _
             ModuleName(Me) & ".CallWorker"
@@ -445,6 +477,125 @@ Private Function CallWorker(strKey As String, dblTimeoutSeconds As Double, _
     CallWorker = lngHandle
 
 End Function
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : JobKeyHash
+' Author    : Adam Waller
+' Date      : 8/23/2026
+' Purpose   : The queue key for a job. Deterministic on purpose: it is what makes the
+'           : duplicate check work, and what the worker echoes back in a callback.
+'---------------------------------------------------------------------------------------
+'
+Private Function JobKeyHash(strKey As String, strAction As String) As String
+    JobKeyHash = GetStringHash(strKey & strAction)
+End Function
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : JobResultFile
+' Author    : Adam Waller
+' Date      : 8/23/2026
+' Purpose   : Path the worker writes a job's return value to, handed to it as an argument
+'           : the same way BuildAndInstall receives its status file. The name carries a
+'           : per-launch suffix, because the queue key cannot serve here: it is a hash of
+'           : key and action, so it is identical in every session and forever, and a file
+'           : left behind by an earlier run would be read as this answer.
+'           : Returns an empty string if the folder cannot be prepared. The worker treats
+'           : that as "do not write", and the caller reads it as no answer.
+'---------------------------------------------------------------------------------------
+'
+Private Function JobResultFile(strAction As String) As String
+
+    ' Well past the longest job timeout, so nothing in flight can match.
+    Const StaleJobHours As Double = 1
+
+    Dim oFS As Object
+    Dim strFolder As String
+    Dim colStale As Collection
+    Dim varFile As Variant
+
+    ' Dereference the FSO getter before opening a handler: it contains LogUnhandledErrors,
+    ' so an error pending on entry would be reported from in here.
+    Set oFS = FSO
+    strFolder = oFS.GetParentFolderName(WorkerFilePath) & PathSep & "WorkerJobs"
+
+    LogUnhandledErrors
+    On Error Resume Next
+
+    ' VerifyPath tells a folder from a file name by the trailing separator.
+    VerifyPath strFolder & PathSep
+
+    If oFS.FolderExists(strFolder) Then
+
+        ' Nothing else collects these, because each name is unique to its launch. Collect
+        ' first and delete afterwards: the Files collection is live.
+        Set colStale = New Collection
+        For Each varFile In oFS.GetFolder(strFolder).Files
+            If varFile.DateLastModified < Now - (StaleJobHours / 24) Then
+                colStale.Add varFile.Path
+            End If
+        Next varFile
+        For Each varFile In colStale
+            DeleteFile CStr(varFile)
+        Next varFile
+
+        JobResultFile = strFolder & PathSep & strAction & "-" & _
+            UniqueHashSuffix(strAction) & ".result"
+    End If
+
+    CatchAny eelWarning, "Unable to prepare the worker result folder: " & strFolder, _
+        ModuleName(Me) & ".JobResultFile"
+
+End Function
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : PollJobResults
+' Author    : Adam Waller
+' Date      : 8/23/2026
+' Purpose   : Pick up a result delivered through the file channel and hand it to
+'           : ReturnWorker, so that job logging and queue removal stay in one place.
+'           : Anything other than the two values the worker writes is left alone and
+'           : retried on the next interval: a read can fail transiently -- a scanner
+'           : holding a file that was just published is the ordinary case -- and
+'           : answering "not accessible" to that would be wrong where waiting one more
+'           : tenth of a second is right. The job timeout already bounds the retrying.
+'---------------------------------------------------------------------------------------
+'
+Private Sub PollJobResults()
+
+    Dim oFS As Object
+    Dim strContent As String
+    Dim strValue As String
+
+    If Len(m_strResultFile) = 0 Then Exit Sub
+
+    Set oFS = FSO
+
+    LogUnhandledErrors
+    On Error Resume Next
+
+    If oFS.FileExists(m_strResultFile) Then
+        strContent = ReadFile(m_strResultFile)
+        If Err.Number = 0 Then
+            ' Split on an empty string returns an array with no elements.
+            If Len(strContent) > 0 Then strValue = Trim(Split(strContent, vbCrLf)(0))
+            Select Case strValue
+                Case "1", "0"
+                    Me.ReturnWorker m_strResultKey, (strValue = "1")
+                    DeleteFile m_strResultFile
+                    m_strResultFile = vbNullString
+                    m_strResultKey = vbNullString
+            End Select
+        End If
+        Err.Clear
+    End If
+
+    CatchAny eelWarning, "Unable to read the worker result file", _
+        ModuleName(Me) & ".PollJobResults"
+
+End Sub
 
 
 '---------------------------------------------------------------------------------------
@@ -531,6 +682,7 @@ Sub Main()
     Dim strPhaseStarted
     Dim strCallbackUrl
     Dim strOperationId
+    Dim strResultFile
 
 
     Set objFSO = CreateObject("Scripting.FileSystemObject")
@@ -556,8 +708,15 @@ Sub Main()
     ' take twenty seconds to say so, which is time spent before this script can report
     ' that it started. Everything that action needs arrives in its own arguments, so it
     ' does not care what the caller had open, or whether it had anything open at all.
+    '
+    ' CheckDatabaseAccessible is the second, and for the same reason read the other way
+    ' round: it builds its own DAO engine and opens the file itself, so the only thing it
+    ' ever used the reference for was handing the answer back. That made the attach a
+    ' dependency taken out purely in order to speak, and it is the one that cannot
+    ' succeed for an add-in path. It reports through a result file instead, so its value
+    ' no longer depends on reaching Access at all.
     Set objApp = Nothing
-    If strAction <> "BuildAndInstall" Then
+    If strAction <> "BuildAndInstall" And strAction <> "CheckDatabaseAccessible" Then
 
         If Not objFSO.FileExists(strValue) Then
             MsgBox "Database file must exist", vbExclamation
@@ -621,7 +780,19 @@ Sub Main()
                 strOperationId
 
         Case "CheckDatabaseAccessible"
-            varReturn = CheckDatabaseAccessible(WScript.Arguments(0))
+            ' Args: result file. The subject is the caller's current database, which
+            ' arrives as argument 0 like everywhere else.
+            '
+            ' The file has to exist, and this action no longer passes through the branch
+            ' that checks it. Guard it here instead, and on a miss write nothing: during
+            ' a full build the database is renamed aside for a moment, and a path that
+            ' resolves to nothing is not an answer. Writing a 0 would turn it into a
+            ' definite "not accessible" and cost the caller a reopen it does not need.
+            strResultFile = ""
+            If WScript.Arguments.Count > 3 Then strResultFile = WScript.Arguments(3)
+            If objFSO.FileExists(strValue) Then
+                WriteJobResult strResultFile, CheckDatabaseAccessible(strValue)
+            End If
 
         Case "SaveVbaProject"
             varReturn = SaveVbaProject(objApp)
@@ -845,6 +1016,40 @@ Function CheckDatabaseAccessible(strPath)
     End If
     Set objEngine = Nothing
 End Function
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : WriteJobResult
+' Author    : Adam Waller
+' Date      : 8/23/2026
+' Purpose   : Report a job's return value through a file, for an action that does not
+'           : attach and so has no callback to make. Written as 1 or 0 rather than as a
+'           : boolean so that nothing in the channel depends on locale, and with the same
+'           : stream and charset as WriteRebuildStatusFile, which is the other file this
+'           : script writes for the add-in to read back.
+'           : Writes nothing when there is no path or no value. The absence of the file is
+'           : how the caller tells "no answer" apart from "no", so writing anything here
+'           : on a miss would destroy the distinction the file exists to make.
+'---------------------------------------------------------------------------------------
+'
+Sub WriteJobResult(strFile, varValue)
+
+    Dim stm
+
+    If Len(strFile) = 0 Then Exit Sub
+    If IsEmpty(varValue) Then Exit Sub
+
+    On Error Resume Next
+    Set stm = CreateObject("ADODB.Stream")
+    stm.Type = 2
+    stm.Charset = "utf-8"
+    stm.Open
+    If varValue Then stm.WriteText "1" Else stm.WriteText "0"
+    stm.SaveToFile strFile, 2
+    stm.Close
+    On Error GoTo 0
+
+End Sub
 
 
 '---------------------------------------------------------------------------------------

--- a/Version Control.accda.src/modules/Integration/clsWorker.cls
+++ b/Version Control.accda.src/modules/Integration/clsWorker.cls
@@ -551,6 +551,34 @@ End Function
 
 
 '---------------------------------------------------------------------------------------
+' Procedure : JobResultFromContent
+' Author    : Ricardo Hernandez (Notarnet)
+' Date      : 9/1/2026
+' Purpose   : Decide whether what was read from a result file is an answer, and which.
+'           : Only the two values the worker writes are a verdict; anything else means
+'           : "no answer yet" and leaves blnAccessible untouched, so a caller cannot
+'           : mistake a transient read for a negative result. Friend scope keeps this
+'           : testable inside the add-in project without exposing it through COM.
+'---------------------------------------------------------------------------------------
+'
+Friend Function JobResultFromContent(ByVal strContent As String, _
+                                     ByRef blnAccessible As Boolean) As Boolean
+
+    Dim strValue As String
+
+    ' Split on an empty string returns an array with no elements.
+    If Len(strContent) > 0 Then strValue = Trim(Split(strContent, vbCrLf)(0))
+
+    Select Case strValue
+        Case "1", "0"
+            blnAccessible = (strValue = "1")
+            JobResultFromContent = True
+    End Select
+
+End Function
+
+
+'---------------------------------------------------------------------------------------
 ' Procedure : PollJobResults
 ' Author    : Adam Waller
 ' Date      : 8/23/2026
@@ -567,7 +595,7 @@ Private Sub PollJobResults()
 
     Dim oFS As Object
     Dim strContent As String
-    Dim strValue As String
+    Dim blnAccessible As Boolean
 
     If Len(m_strResultFile) = 0 Then Exit Sub
 
@@ -579,15 +607,12 @@ Private Sub PollJobResults()
     If oFS.FileExists(m_strResultFile) Then
         strContent = ReadFile(m_strResultFile)
         If Err.Number = 0 Then
-            ' Split on an empty string returns an array with no elements.
-            If Len(strContent) > 0 Then strValue = Trim(Split(strContent, vbCrLf)(0))
-            Select Case strValue
-                Case "1", "0"
-                    Me.ReturnWorker m_strResultKey, (strValue = "1")
-                    DeleteFile m_strResultFile
-                    m_strResultFile = vbNullString
-                    m_strResultKey = vbNullString
-            End Select
+            If JobResultFromContent(strContent, blnAccessible) Then
+                Me.ReturnWorker m_strResultKey, blnAccessible
+                DeleteFile m_strResultFile
+                m_strResultFile = vbNullString
+                m_strResultKey = vbNullString
+            End If
         End If
         Err.Clear
     End If

--- a/Version Control.accda.src/modules/Integration/clsWorker.cls
+++ b/Version Control.accda.src/modules/Integration/clsWorker.cls
@@ -33,15 +33,6 @@ Option Explicit
 ' Worker Job queue of jobs in progress
 Public Queue As Dictionary
 
-' Last result returned by a worker callback
-Private m_varLastResult As Variant
-
-' Result file and queue key of the job reporting through the file channel, if any. One
-' field each for the same reason m_varLastResult is one field: only one job at a time can
-' be waited on for a value, and the duplicate-job guard in CallWorker keeps it that way.
-Private m_strResultFile As String
-Private m_strResultKey As String
-
 ' Generic placeholder objects so we can compile the VBScript in the VBA IDE
 Private WScript As Object
 
@@ -103,32 +94,30 @@ End Function
 '           : cannot detect.
 '---------------------------------------------------------------------------------------
 '
-Public Function IsDatabaseAccessible() As Boolean
+Public Function IsDatabaseAccessible() As Variant
 
     ' This action reports through a file instead of the callback. It is the only one that
     ' does not need the Access instance to do its work -- it builds its own DAO engine --
     ' so attaching would be a dependency taken out purely in order to answer, and that is
     ' the attach that cannot succeed when the caller's current database is the add-in
     ' itself. See the 2026-08-12 entry in DECISIONS.md for the measured 432.
-    m_varLastResult = Empty
-    m_strResultKey = JobKeyHash("DbAccessCheck", "CheckDatabaseAccessible")
-    m_strResultFile = JobResultFile("CheckDatabaseAccessible")
-    CallWorker "DbAccessCheck", 10, "CheckDatabaseAccessible", """" & m_strResultFile & """"
-    Me.WaitForQueue 10, "CheckDatabaseAccessible", 0.1
+    Dim cJob As clsJob
+    Dim strFile As String
 
-    ' Three outcomes, not two. No file at all means the worker never answered, which is
-    ' not the same as an answer of "not accessible" even though the caller takes the same
-    ' conservative action either way. Stay quiet when the helper script is switched off
-    ' (#727): there an empty result is the documented behaviour, not a fault.
-    If IsEmpty(m_varLastResult) Then
-        If modInstall.UseWorkerScript Then
-            Log.Error eelWarning, T("No result from the worker. Assuming the database is not accessible to other clients."), _
-                ModuleName(Me) & ".IsDatabaseAccessible"
-        End If
-        IsDatabaseAccessible = False
-    Else
-        IsDatabaseAccessible = CBool(m_varLastResult)
+    ' Three outcomes, not two: True, False, or Empty. Empty means the worker never
+    ' answered (disabled, failed launch, timeout, or explicit unknown). Callers that
+    ' need a Boolean collapse that at their policy boundary; this function must not.
+    strFile = ReserveJobResultFile("CheckDatabaseAccessible")
+    If Len(strFile) = 0 Then Exit Function
+
+    Set cJob = CallWorker("DbAccessCheck", 10, "CheckDatabaseAccessible", """" & strFile & """")
+    If cJob Is Nothing Then
+        DeleteFile strFile
+        Exit Function
     End If
+    cJob.ResultFile = strFile
+    Me.WaitForQueue 10, "CheckDatabaseAccessible", 0.1
+    IsDatabaseAccessible = cJob.Result
 
 End Function
 
@@ -145,10 +134,14 @@ End Function
 '---------------------------------------------------------------------------------------
 '
 Public Function Run_SaveVbaProject() As Boolean
-    m_varLastResult = Empty
-    CallWorker "VbaProjectSave", 30, "SaveVbaProject"
+
+    Dim cJob As clsJob
+
+    Set cJob = CallWorker("VbaProjectSave", 30, "SaveVbaProject")
+    If cJob Is Nothing Then Exit Function
     Me.WaitForQueue 30, "SaveVbaProject", 0.1
-    Run_SaveVbaProject = CBool(m_varLastResult)
+    If Not IsEmpty(cJob.Result) Then Run_SaveVbaProject = CBool(cJob.Result)
+
 End Function
 
 
@@ -259,24 +252,28 @@ Public Sub WaitForQueue(dblTimeout As Double, Optional strAction As String = "Al
         Next varKey
         Set cJob = Nothing
 
-        ' Log and remove any individual jobs that have timed out
+        ' Log and expire any individual jobs that have timed out. ExpireJob
+        ' deletes a reserved result file so a late write cannot complete later.
         For Each varJob In colRemove
-            Set cJob = Me.Queue(varJob)
-            With cJob
-                Log.Error eelError, "Job " & .KeyHash & " (" & .Action & ") timed out after " & _
-                    Round(Perf.MicroTimer - .Start, 0) & " seconds.", ModuleName(Me) & ".WaitForQueue"
-            End With
-            Set cJob = Nothing
-            If Me.Queue.Exists(varJob) Then Me.Queue.Remove varJob
+            If Me.Queue.Exists(varJob) Then
+                Set cJob = Me.Queue(varJob)
+                Log.Error eelError, T("Job {0} ({1}) timed out after {2} seconds.", _
+                    var0:=cJob.KeyHash, var1:=cJob.Action, _
+                    var2:=Round(Perf.MicroTimer - cJob.Start, 0)), _
+                    ModuleName(Me) & ".WaitForQueue"
+                ExpireJob cJob
+            End If
         Next varJob
+        Set colRemove = New Collection
 
         ' If nothing found of a specified action, we can exit the loop
         If (strAction <> "All") And (Not blnFound) Then Exit Do
 
         ' Check the overall timeout before we start another iteration
         If dblStart + dblTimeout < Perf.MicroTimer Then
-            Log.Error eelError, "Timed out waiting for job queue", ModuleName(Me) & ".WaitForQueue"
+            Log.Error eelError, T("Timed out waiting for job queue"), ModuleName(Me) & ".WaitForQueue"
             Log.Add " (" & Me.Queue.Count & " jobs still in the queue.)", False
+            ExpireFileChannelJobs
             Exit Do
         End If
     Loop
@@ -396,6 +393,7 @@ Public Sub RemoveWorkerScript()
     DeleteFile WorkerFilePath, True
     CatchAny eelWarning, T("Unable to remove worker script: {0}", var0:=WorkerFilePath), _
         ModuleName(Me) & ".RemoveWorkerScript"
+    RemoveWorkerJobsFolder
 End Sub
 
 
@@ -407,11 +405,10 @@ End Sub
 '---------------------------------------------------------------------------------------
 '
 Private Function CallWorker(strKey As String, dblTimeoutSeconds As Double, _
-    strAction As String, ParamArray varParams()) As Long
+    strAction As String, ParamArray varParams()) As clsJob
 
     Dim intParam As Integer
     Dim strHash As String
-    Dim lngHandle As Long
     Dim cJob As clsJob
 
     ' The user can turn the helper script off when their environment does not allow
@@ -429,7 +426,7 @@ Private Function CallWorker(strKey As String, dblTimeoutSeconds As Double, _
     ' Make sure this key/action is not already running
     strHash = JobKeyHash(strKey, strAction)
     If Me.Queue.Exists(strHash) Then
-        Log.Error eelError, "Duplicate job in queue: " & strAction & "." & strKey, _
+        Log.Error eelError, T("Duplicate job in queue: {0}.{1}", var0:=strAction, var1:=strKey), _
             ModuleName(Me) & ".CallWorker"
         Exit Function
     End If
@@ -467,14 +464,12 @@ Private Function CallWorker(strKey As String, dblTimeoutSeconds As Double, _
         End With
         Me.Queue.Add strHash, cJob
 
-        ' Use the Shell command to launch the worker as an external asynchrous
-        ' process, and return the process ID to the caller.
-        lngHandle = Shell(.GetStr, vbHide)
+        ' Launch the worker as an external asynchronous process.
+        Shell .GetStr, vbHide
 
     End With
 
-    ' Return process handle
-    CallWorker = lngHandle
+    Set CallWorker = cJob
 
 End Function
 
@@ -493,59 +488,77 @@ End Function
 
 
 '---------------------------------------------------------------------------------------
-' Procedure : JobResultFile
+' Procedure : WorkerJobsFolder
 ' Author    : Adam Waller
-' Date      : 8/23/2026
-' Purpose   : Path the worker writes a job's return value to, handed to it as an argument
-'           : the same way BuildAndInstall receives its status file. The name carries a
-'           : per-launch suffix, because the queue key cannot serve here: it is a hash of
-'           : key and action, so it is identical in every session and forever, and a file
-'           : left behind by an earlier run would be read as this answer.
-'           : Returns an empty string if the folder cannot be prepared. The worker treats
-'           : that as "do not write", and the caller reads it as no answer.
+' Date      : 9/7/2026
+' Purpose   : Folder for nonce-named worker result files, beside Worker.vbs.
 '---------------------------------------------------------------------------------------
 '
-Private Function JobResultFile(strAction As String) As String
+Friend Property Get WorkerJobsFolder() As String
+    WorkerJobsFolder = FSO.GetParentFolderName(WorkerFilePath) & PathSep & "WorkerJobs"
+End Property
 
-    ' Well past the longest job timeout, so nothing in flight can match.
+
+'---------------------------------------------------------------------------------------
+' Procedure : ReserveJobResultFile
+' Author    : Adam Waller
+' Date      : 9/7/2026
+' Purpose   : Create-new reservation of a result path so two Access processes cannot
+'           : share a name. The suffix includes this process id plus UniqueHashSuffix;
+'           : CreateTextFile(overwrite:=False) is the exclusive claim. Empty string
+'           : means the folder could not be prepared or every attempt collided.
+'---------------------------------------------------------------------------------------
+'
+Friend Function ReserveJobResultFile(Optional strAction As String = "CheckDatabaseAccessible") As String
+
     Const StaleJobHours As Double = 1
+    Const MaxAttempts As Long = 8
 
     Dim oFS As Object
     Dim strFolder As String
     Dim colStale As Collection
     Dim varFile As Variant
+    Dim lngAttempt As Long
+    Dim strPath As String
+    Dim ts As Object
 
-    ' Dereference the FSO getter before opening a handler: it contains LogUnhandledErrors,
-    ' so an error pending on entry would be reported from in here.
     Set oFS = FSO
-    strFolder = oFS.GetParentFolderName(WorkerFilePath) & PathSep & "WorkerJobs"
+    strFolder = WorkerJobsFolder
 
     LogUnhandledErrors
     On Error Resume Next
-
-    ' VerifyPath tells a folder from a file name by the trailing separator.
     VerifyPath strFolder & PathSep
+    If CatchAny(eelWarning, T("Unable to prepare the worker result folder: {0}", var0:=strFolder), _
+        ModuleName(Me) & ".ReserveJobResultFile") Then Exit Function
 
-    If oFS.FolderExists(strFolder) Then
+    If Not oFS.FolderExists(strFolder) Then Exit Function
 
-        ' Nothing else collects these, because each name is unique to its launch. Collect
-        ' first and delete afterwards: the Files collection is live.
-        Set colStale = New Collection
-        For Each varFile In oFS.GetFolder(strFolder).Files
-            If varFile.DateLastModified < Now - (StaleJobHours / 24) Then
-                colStale.Add varFile.Path
-            End If
-        Next varFile
-        For Each varFile In colStale
-            DeleteFile CStr(varFile)
-        Next varFile
+    Set colStale = New Collection
+    For Each varFile In oFS.GetFolder(strFolder).Files
+        If varFile.DateLastModified < Now - (StaleJobHours / 24) Then
+            colStale.Add varFile.Path
+        End If
+    Next varFile
+    For Each varFile In colStale
+        DeleteFile CStr(varFile)
+    Next varFile
 
-        JobResultFile = strFolder & PathSep & strAction & "-" & _
+    For lngAttempt = 1 To MaxAttempts
+        Err.Clear
+        strPath = strFolder & PathSep & strAction & "-" & _
+            CStr(modInstall.GetThisProcessId) & "-" & _
             UniqueHashSuffix(strAction) & ".result"
-    End If
+        Set ts = oFS.CreateTextFile(strPath, False)
+        If Err.Number = 0 Then
+            ts.Close
+            ReserveJobResultFile = strPath
+            Exit Function
+        End If
+        Err.Clear
+    Next lngAttempt
 
-    CatchAny eelWarning, "Unable to prepare the worker result folder: " & strFolder, _
-        ModuleName(Me) & ".JobResultFile"
+    Log.Error eelWarning, T("Unable to reserve a worker result file in {0}", var0:=strFolder), _
+        ModuleName(Me) & ".ReserveJobResultFile"
 
 End Function
 
@@ -554,24 +567,30 @@ End Function
 ' Procedure : JobResultFromContent
 ' Author    : Ricardo Hernandez (Notarnet)
 ' Date      : 9/1/2026
-' Purpose   : Decide whether what was read from a result file is an answer, and which.
-'           : Only the two values the worker writes are a verdict; anything else means
-'           : "no answer yet" and leaves blnAccessible untouched, so a caller cannot
-'           : mistake a transient read for a negative result. Friend scope keeps this
-'           : testable inside the add-in project without exposing it through COM.
+' Purpose   : Decide whether what was read from a result file is a terminal answer.
+'           : "1" and "0" are True/False. "U" is explicit unknown (Empty). Anything
+'           : else is not an answer yet and leaves varResult untouched so a transient
+'           : read cannot become a negative result. Friend scope keeps this testable
+'           : without exposing it through COM.
 '---------------------------------------------------------------------------------------
 '
 Friend Function JobResultFromContent(ByVal strContent As String, _
-                                     ByRef blnAccessible As Boolean) As Boolean
+                                     ByRef varResult As Variant) As Boolean
 
     Dim strValue As String
 
     ' Split on an empty string returns an array with no elements.
-    If Len(strContent) > 0 Then strValue = Trim(Split(strContent, vbCrLf)(0))
+    If Len(strContent) > 0 Then strValue = Trim$(Split(strContent, vbCrLf)(0))
 
     Select Case strValue
-        Case "1", "0"
-            blnAccessible = (strValue = "1")
+        Case "1"
+            varResult = True
+            JobResultFromContent = True
+        Case "0"
+            varResult = False
+            JobResultFromContent = True
+        Case "U"
+            varResult = Empty
             JobResultFromContent = True
     End Select
 
@@ -579,46 +598,237 @@ End Function
 
 
 '---------------------------------------------------------------------------------------
+' Procedure : AccessibilityFromProbeResult
+' Author    : Adam Waller
+' Date      : 9/7/2026
+' Purpose   : Collapse a probe transport result to the conservative Boolean the build
+'           : callers need. Empty/unknown is False. Logging stays at the policy
+'           : boundary in modBuild so tests can assert the decision without writing
+'           : to the session log.
+'---------------------------------------------------------------------------------------
+'
+Friend Function AccessibilityFromProbeResult(ByVal varResult As Variant) As Boolean
+    If IsEmpty(varResult) Then Exit Function
+    AccessibilityFromProbeResult = CBool(varResult)
+End Function
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : QueueFileResultJob
+' Author    : Adam Waller
+' Date      : 9/7/2026
+' Purpose   : Test seam: enqueue a file-channel job without launching wscript.
+'           : Returns Nothing when the key is already queued.
+'---------------------------------------------------------------------------------------
+'
+Friend Function QueueFileResultJob(strKey As String, strAction As String, _
+    strResultFile As String, Optional dblTimeoutSeconds As Double = 10) As clsJob
+
+    Dim strHash As String
+    Dim cJob As clsJob
+
+    If Me.Queue Is Nothing Then Set Me.Queue = New Dictionary
+    strHash = JobKeyHash(strKey, strAction)
+    If Me.Queue.Exists(strHash) Then Exit Function
+
+    Set cJob = New clsJob
+    cJob.KeyHash = strHash
+    cJob.Action = strAction
+    cJob.Start = Perf.MicroTimer
+    cJob.Timeout = cJob.Start + dblTimeoutSeconds
+    cJob.ResultFile = strResultFile
+    Me.Queue.Add strHash, cJob
+    Set QueueFileResultJob = cJob
+
+End Function
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : ExpireJob
+' Author    : Adam Waller
+' Date      : 9/7/2026
+' Purpose   : Mark a job expired, delete its result file, and drop it from the queue.
+'           : A late worker write to the old path is then ignored because polling only
+'           : looks at queued jobs.
+'---------------------------------------------------------------------------------------
+'
+Friend Sub ExpireJob(cJob As clsJob)
+    If cJob Is Nothing Then Exit Sub
+    cJob.ResultExpired = True
+    If Len(cJob.ResultFile) > 0 Then
+        DeleteFile cJob.ResultFile
+        cJob.ResultFile = vbNullString
+    End If
+    If Not Me.Queue Is Nothing Then
+        If Me.Queue.Exists(cJob.KeyHash) Then Me.Queue.Remove cJob.KeyHash
+    End If
+End Sub
+
+
+'---------------------------------------------------------------------------------------
 ' Procedure : PollJobResults
 ' Author    : Adam Waller
 ' Date      : 8/23/2026
-' Purpose   : Pick up a result delivered through the file channel and hand it to
-'           : ReturnWorker, so that job logging and queue removal stay in one place.
-'           : Anything other than the two values the worker writes is left alone and
-'           : retried on the next interval: a read can fail transiently -- a scanner
-'           : holding a file that was just published is the ordinary case -- and
-'           : answering "not accessible" to that would be wrong where waiting one more
-'           : tenth of a second is right. The job timeout already bounds the retrying.
+' Purpose   : Pick up results delivered through the file channel and hand them to
+'           : ReturnWorker, so job logging and queue removal stay in one place.
+'           : Anything other than a terminal token is left alone and retried on the
+'           : next interval. The job timeout bounds the retrying.
 '---------------------------------------------------------------------------------------
 '
-Private Sub PollJobResults()
+Friend Sub PollJobResults()
 
-    Dim oFS As Object
+    Dim varKey As Variant
+    Dim colKeys As Collection
+    Dim cJob As clsJob
+
+    If Me.Queue Is Nothing Then Exit Sub
+    If Me.Queue.Count = 0 Then Exit Sub
+
+    Set colKeys = New Collection
+    For Each varKey In Me.Queue.Keys
+        colKeys.Add CStr(varKey)
+    Next varKey
+
+    For Each varKey In colKeys
+        If Me.Queue.Exists(CStr(varKey)) Then
+            Set cJob = Me.Queue(CStr(varKey))
+            If Len(cJob.ResultFile) > 0 Then ConsumeJobResultFile cJob
+        End If
+    Next varKey
+
+End Sub
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : ConsumeJobResultFile
+' Author    : Adam Waller
+' Date      : 9/7/2026
+' Purpose   : Read one job's result file. File observation errors are retried; queue
+'           : completion must succeed before the file is deleted.
+'---------------------------------------------------------------------------------------
+'
+Private Sub ConsumeJobResultFile(cJob As clsJob)
+
     Dim strContent As String
-    Dim blnAccessible As Boolean
+    Dim varResult As Variant
 
-    If Len(m_strResultFile) = 0 Then Exit Sub
+    If cJob.ResultExpired Then
+        DeleteFile cJob.ResultFile
+        cJob.ResultFile = vbNullString
+        Exit Sub
+    End If
 
-    Set oFS = FSO
+    If Not FileExistsSafe(cJob.ResultFile) Then Exit Sub
+    If Not TryReadJobResult(cJob.ResultFile, strContent) Then Exit Sub
+    If Not JobResultFromContent(strContent, varResult) Then Exit Sub
+    If Not Me.Queue.Exists(cJob.KeyHash) Then
+        DeleteFile cJob.ResultFile
+        cJob.ResultFile = vbNullString
+        Exit Sub
+    End If
+
+    cJob.Result = varResult
+    Me.ReturnWorker cJob.KeyHash, varResult
+    If Me.Queue.Exists(cJob.KeyHash) Then Exit Sub
+
+    DeleteFile cJob.ResultFile
+    cJob.ResultFile = vbNullString
+
+End Sub
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : TryReadJobResult
+' Author    : Adam Waller
+' Date      : 9/7/2026
+' Purpose   : Read a short result file without using ReadFile, whose Perf frame is
+'           : not closed when LoadFromFile fails. A sharing violation is retried on
+'           : the next poll interval rather than treated as a verdict.
+'---------------------------------------------------------------------------------------
+'
+Private Function TryReadJobResult(strPath As String, ByRef strContent As String) As Boolean
+
+    Dim stm As ADODB.Stream
 
     LogUnhandledErrors
     On Error Resume Next
 
-    If oFS.FileExists(m_strResultFile) Then
-        strContent = ReadFile(m_strResultFile)
+    Set stm = New ADODB.Stream
+    stm.Charset = "utf-8"
+    stm.Open
+    stm.LoadFromFile strPath
+    If Err.Number = 0 Then
+        strContent = stm.ReadText
         If Err.Number = 0 Then
-            If JobResultFromContent(strContent, blnAccessible) Then
-                Me.ReturnWorker m_strResultKey, blnAccessible
-                DeleteFile m_strResultFile
-                m_strResultFile = vbNullString
-                m_strResultKey = vbNullString
-            End If
+            If Left$(strContent, 1) = ChrW$(&HFEFF) Then strContent = Mid$(strContent, 2)
+            TryReadJobResult = True
         End If
-        Err.Clear
     End If
+    stm.Close
+    Err.Clear
 
-    CatchAny eelWarning, "Unable to read the worker result file", _
-        ModuleName(Me) & ".PollJobResults"
+End Function
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : FileExistsSafe
+' Author    : Adam Waller
+' Date      : 9/7/2026
+' Purpose   : Existence check that swallows a transient scan error instead of raising.
+'---------------------------------------------------------------------------------------
+'
+Private Function FileExistsSafe(strPath As String) As Boolean
+    LogUnhandledErrors
+    On Error Resume Next
+    FileExistsSafe = FSO.FileExists(strPath)
+    If Err.Number Then Err.Clear
+End Function
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : ExpireFileChannelJobs
+' Author    : Adam Waller
+' Date      : 9/7/2026
+' Purpose   : After an overall wait timeout, expire remaining file-channel jobs so a
+'           : late write cannot complete a later operation.
+'---------------------------------------------------------------------------------------
+'
+Private Sub ExpireFileChannelJobs()
+
+    Dim varKey As Variant
+    Dim colJobs As Collection
+    Dim cJob As clsJob
+
+    If Me.Queue Is Nothing Then Exit Sub
+    Set colJobs = New Collection
+    For Each varKey In Me.Queue.Keys
+        Set cJob = Me.Queue(varKey)
+        If Len(cJob.ResultFile) > 0 Then colJobs.Add cJob
+    Next varKey
+    For Each cJob In colJobs
+        ExpireJob cJob
+    Next cJob
+
+End Sub
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : RemoveWorkerJobsFolder
+' Author    : Adam Waller
+' Date      : 9/7/2026
+' Purpose   : Remove leftover result files when the helper script is disabled or
+'           : uninstalled.
+'---------------------------------------------------------------------------------------
+'
+Private Sub RemoveWorkerJobsFolder()
+
+    Dim strFolder As String
+
+    strFolder = WorkerJobsFolder
+    If DebugMode(True) Then On Error GoTo 0 Else On Error Resume Next
+    If FSO.FolderExists(strFolder) Then FSO.DeleteFolder strFolder, True
+    CatchAny eelWarning, T("Unable to remove worker result folder: {0}", var0:=strFolder), _
+        ModuleName(Me) & ".RemoveWorkerJobsFolder"
 
 End Sub
 
@@ -658,8 +868,9 @@ Public Function ReturnWorker(strKey As String, varParams As Variant)
         Set cJob = Me.Queue(strKey)
     End If
 
-    ' Store the return value so the caller can read it after WaitForQueue
-    m_varLastResult = varParams
+    ' Store the return value on the job so the caller that holds this
+    ' reference can read it after the queue entry is removed.
+    cJob.Result = varParams
 
     ' Log and remove from job queue
     With cJob
@@ -815,8 +1026,13 @@ Sub Main()
             ' definite "not accessible" and cost the caller a reopen it does not need.
             strResultFile = ""
             If WScript.Arguments.Count > 3 Then strResultFile = WScript.Arguments(3)
-            If objFSO.FileExists(strValue) Then
+            If WaitForDatabaseFile(objFSO, strValue) Then
                 WriteJobResult strResultFile, CheckDatabaseAccessible(strValue)
+            Else
+                ' Path still missing after a brief retry (a full build can rename
+                ' the database aside). Publish unknown so the parent can finish
+                ' conservatively without waiting the full job timeout.
+                WriteJobResult strResultFile, Empty
             End If
 
         Case "SaveVbaProject"
@@ -974,6 +1190,7 @@ Function UninstallAddIn(objApp, strAddInFile)
 
     Dim objFSO
     Dim strLockFile
+    Dim strFolder
     Dim intCnt
 
     Set objFSO = CreateObject("Scripting.FileSystemObject")
@@ -1008,7 +1225,9 @@ Function UninstallAddIn(objApp, strAddInFile)
             " The file might be in use by another instance of Microsoft Access." & vbCrLf & vbCrLf & _
             "Error " & Err.Number & ": " & Err.Description, vbExclamation
     Else
-        ' Delete this worker script file.
+        ' Delete leftover result files, then this worker script.
+        strFolder = objFSO.GetParentFolderName(WScript.ScriptFullName) & "\WorkerJobs"
+        If objFSO.FolderExists(strFolder) Then objFSO.DeleteFolder strFolder, True
         objFSO.DeleteFile WScript.ScriptFullName
         WScript.Quit
     End If
@@ -1052,29 +1271,62 @@ End Function
 '           : boolean so that nothing in the channel depends on locale, and with the same
 '           : stream and charset as WriteRebuildStatusFile, which is the other file this
 '           : script writes for the add-in to read back.
-'           : Writes nothing when there is no path or no value. The absence of the file is
-'           : how the caller tells "no answer" apart from "no", so writing anything here
-'           : on a miss would destroy the distinction the file exists to make.
+'           : Writes "1", "0", or "U" (unknown). Empty is a published unknown, not
+'           : "do not write": the parent must be able to finish without waiting out
+'           : the job timeout when the path is briefly gone.
 '---------------------------------------------------------------------------------------
 '
 Sub WriteJobResult(strFile, varValue)
 
     Dim stm
+    Dim strToken
 
     If Len(strFile) = 0 Then Exit Sub
-    If IsEmpty(varValue) Then Exit Sub
+
+    If IsEmpty(varValue) Then
+        strToken = "U"
+    ElseIf varValue Then
+        strToken = "1"
+    Else
+        strToken = "0"
+    End If
 
     On Error Resume Next
     Set stm = CreateObject("ADODB.Stream")
     stm.Type = 2
     stm.Charset = "utf-8"
     stm.Open
-    If varValue Then stm.WriteText "1" Else stm.WriteText "0"
+    stm.WriteText strToken
     stm.SaveToFile strFile, 2
     stm.Close
     On Error GoTo 0
 
 End Sub
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : WaitForDatabaseFile
+' Author    : Adam Waller
+' Date      : 9/7/2026
+' Purpose   : The database can be renamed aside for a moment during a full build.
+'           : Retry briefly so a transient miss is not published as unknown, then
+'           : give up so the parent is not left on the full job timeout.
+'---------------------------------------------------------------------------------------
+'
+Function WaitForDatabaseFile(objFSO, strPath)
+    Dim i
+    If objFSO.FileExists(strPath) Then
+        WaitForDatabaseFile = True
+        Exit Function
+    End If
+    For i = 1 To 5
+        WScript.Sleep 50
+        If objFSO.FileExists(strPath) Then
+            WaitForDatabaseFile = True
+            Exit Function
+        End If
+    Next
+End Function
 
 
 '---------------------------------------------------------------------------------------

--- a/Version Control.accda.src/modules/Tests/Infrastructure/clsTestWorkerLifecycle.cls
+++ b/Version Control.accda.src/modules/Tests/Infrastructure/clsTestWorkerLifecycle.cls
@@ -1,0 +1,201 @@
+﻿VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = "clsTestWorkerLifecycle"
+Attribute VB_GlobalNameSpace = False
+Attribute VB_Creatable = False
+Attribute VB_PredeclaredId = False
+Attribute VB_Exposed = False
+'---------------------------------------------------------------------------------------
+' Module    : clsTestWorkerLifecycle
+' Author    : Adam Waller
+' Date      : 9/7/2026
+' Purpose   : Queue-lifecycle tests for the worker file result channel, plus an
+'           : end-to-end probe against the current database. Uses Friend seams so
+'           : timeout and late-write cases do not log session errors.
+'---------------------------------------------------------------------------------------
+Option Compare Database
+Option Explicit
+'@Folder("Tests.Infrastructure")
+'@Tag("unit")
+
+Private m_strTempFolder As String
+
+
+Private Sub Class_Initialize()
+    m_strTempFolder = GetTempFolder("vcs_worker_result")
+End Sub
+
+
+Private Sub Class_Terminate()
+    If Len(m_strTempFolder) > 0 Then
+        If FSO.FolderExists(m_strTempFolder) Then FSO.DeleteFolder StripSlash(m_strTempFolder), True
+    End If
+End Sub
+
+
+Public Sub TestQueueFileResultCompletesAndDeletesFile()
+
+    Dim cWorker As clsWorker
+    Dim cJob As clsJob
+    Dim strFile As String
+
+    Set cWorker = New clsWorker
+    strFile = WriteTokenFile("1")
+    Set cJob = cWorker.QueueFileResultJob("lifecycle-complete", "CheckDatabaseAccessible", strFile)
+    TestAssert Not cJob Is Nothing, "job was queued"
+    cWorker.PollJobResults
+
+    TestAssert cJob.Result = True, "1 completed as accessible"
+    TestAssert Not cWorker.Queue.Exists(cJob.KeyHash), "queue entry removed"
+    TestAssert Not FSO.FileExists(strFile), "result file deleted after completion"
+
+End Sub
+
+
+Public Sub TestQueueFileResultUnknownCompletes()
+
+    Dim cWorker As clsWorker
+    Dim cJob As clsJob
+    Dim strFile As String
+
+    Set cWorker = New clsWorker
+    strFile = WriteTokenFile("U")
+    Set cJob = cWorker.QueueFileResultJob("lifecycle-unknown", "CheckDatabaseAccessible", strFile)
+    cWorker.PollJobResults
+
+    TestAssert IsEmpty(cJob.Result), "U completes as Empty"
+    TestAssert Not cWorker.Queue.Exists(cJob.KeyHash), "queue entry removed after unknown"
+
+End Sub
+
+
+Public Sub TestQueueFileResultIgnoresPartialContent()
+
+    Dim cWorker As clsWorker
+    Dim cJob As clsJob
+    Dim strFile As String
+
+    Set cWorker = New clsWorker
+    strFile = WriteTokenFile("10")
+    Set cJob = cWorker.QueueFileResultJob("lifecycle-partial", "CheckDatabaseAccessible", strFile)
+    cWorker.PollJobResults
+
+    TestAssert IsEmpty(cJob.Result), "partial content is not a verdict"
+    TestAssert cWorker.Queue.Exists(cJob.KeyHash), "job stays queued for retry"
+    TestAssert FSO.FileExists(strFile), "file kept until a real token arrives"
+
+    WriteFile "0", strFile
+    cWorker.PollJobResults
+    TestAssert cJob.Result = False, "later 0 is accepted"
+    TestAssert Not cWorker.Queue.Exists(cJob.KeyHash), "queue cleared after the real token"
+
+End Sub
+
+
+Public Sub TestDuplicateEnqueueLeavesFirstJob()
+
+    Dim cWorker As clsWorker
+    Dim cFirst As clsJob
+    Dim cSecond As clsJob
+    Dim strFile As String
+
+    Set cWorker = New clsWorker
+    strFile = WriteTokenFile(vbNullString)
+    Set cFirst = cWorker.QueueFileResultJob("lifecycle-dup", "CheckDatabaseAccessible", strFile)
+    Set cSecond = cWorker.QueueFileResultJob("lifecycle-dup", "CheckDatabaseAccessible", strFile)
+
+    TestAssert Not cFirst Is Nothing, "first enqueue succeeds"
+    TestAssert cSecond Is Nothing, "duplicate key is rejected without replacing the first"
+    TestAssert cWorker.Queue.Count = 1, "only one job is queued"
+
+End Sub
+
+
+Public Sub TestExpireJobIgnoresLatePublication()
+
+    Dim cWorker As clsWorker
+    Dim cExpired As clsJob
+    Dim cLater As clsJob
+    Dim strExpired As String
+    Dim strLater As String
+
+    Set cWorker = New clsWorker
+    strExpired = WriteTokenFile(vbNullString)
+    Set cExpired = cWorker.QueueFileResultJob("lifecycle-late", "CheckDatabaseAccessible", strExpired)
+    cWorker.ExpireJob cExpired
+
+    TestAssert Not cWorker.Queue.Exists(cExpired.KeyHash), "expired job left the queue"
+    TestAssert Not FSO.FileExists(strExpired), "reserved file deleted on expire"
+
+    ' Simulate a late worker write to the old path after expiry.
+    WriteFile "1", strExpired
+
+    strLater = WriteTokenFile(vbNullString)
+    Set cLater = cWorker.QueueFileResultJob("lifecycle-later", "CheckDatabaseAccessible", strLater)
+    cWorker.PollJobResults
+
+    TestAssert IsEmpty(cLater.Result), "later job is not completed by the stale file"
+    TestAssert cWorker.Queue.Exists(cLater.KeyHash), "later job is still waiting on its own file"
+    TestAssert cWorker.Queue.Count = 1, "expired job was not resurrected"
+
+    cWorker.ExpireJob cLater
+    If FSO.FileExists(strExpired) Then DeleteFile strExpired
+
+End Sub
+
+
+Public Sub TestReserveJobResultFileIsExclusive()
+
+    Dim cWorker As clsWorker
+    Dim strFirst As String
+    Dim strSecond As String
+
+    Set cWorker = New clsWorker
+    strFirst = cWorker.ReserveJobResultFile("CheckDatabaseAccessible")
+    strSecond = cWorker.ReserveJobResultFile("CheckDatabaseAccessible")
+
+    TestAssert Len(strFirst) > 0, "first reservation produced a path"
+    TestAssert Len(strSecond) > 0, "second reservation produced a path"
+    TestAssert strFirst <> strSecond, "reservations do not share a name"
+    TestAssert FSO.FileExists(strFirst), "first path was created exclusively"
+    TestAssert FSO.FileExists(strSecond), "second path was created exclusively"
+
+    DeleteFile strFirst
+    DeleteFile strSecond
+
+End Sub
+
+
+Public Sub TestIsDatabaseAccessibleFileChannelCompletes()
+
+    Dim cWorker As clsWorker
+    Dim varResult As Variant
+
+    If Not modInstall.UseWorkerScript Then
+        Set cWorker = New clsWorker
+        varResult = cWorker.IsDatabaseAccessible
+        TestAssert IsEmpty(varResult), "disabled worker returns Empty without launching"
+        Exit Sub
+    End If
+
+    Set cWorker = New clsWorker
+    varResult = cWorker.IsDatabaseAccessible
+    TestAssert Not IsEmpty(varResult), "probe returned a verdict through the file channel"
+    TestAssert varResult = True Or varResult = False, "verdict is 1 or 0"
+    TestAssert cWorker.Queue.Count = 0, "queue is empty after the probe"
+
+End Sub
+
+
+Private Function WriteTokenFile(strToken As String) As String
+    WriteTokenFile = m_strTempFolder & PathSep & UniqueHashSuffix("worker-result") & ".result"
+    ' WriteFile deletes the path when the text is empty; keep a non-verdict
+    ' placeholder so PollJobResults can observe the file.
+    If Len(strToken) = 0 Then
+        WriteFile " ", WriteTokenFile
+    Else
+        WriteFile strToken, WriteTokenFile
+    End If
+End Function

--- a/Version Control.accda.src/modules/Tests/Infrastructure/modTestWorkerResult.bas
+++ b/Version Control.accda.src/modules/Tests/Infrastructure/modTestWorkerResult.bas
@@ -1,0 +1,70 @@
+﻿Attribute VB_Name = "modTestWorkerResult"
+'---------------------------------------------------------------------------------------
+' Module    : modTestWorkerResult
+' Author    : Ricardo Hernandez (Notarnet)
+' Date      : 9/1/2026
+' Purpose   : Unit tests for the worker's file result channel: what counts as an answer
+'           : from the accessibility probe and what does not. The distinction matters
+'           : because a read can fail transiently, and answering "not accessible" to
+'           : that would be a false negative that is silent and intermittent.
+'---------------------------------------------------------------------------------------
+Option Compare Database
+Option Explicit
+Option Private Module
+'@Folder("Tests.Infrastructure")
+'@Tag("unit")
+
+
+Public Sub TestWorkerResultAcceptsOnlyTheTwoWrittenValues()
+
+    Dim cWorker As clsWorker
+    Dim blnAccessible As Boolean
+    Dim blnIsVerdict As Boolean
+
+    Set cWorker = New clsWorker
+
+    blnIsVerdict = cWorker.JobResultFromContent("1", blnAccessible)
+    TestAssert blnIsVerdict, "1 is a verdict"
+    TestAssert blnAccessible, "1 means the database is accessible"
+
+    blnIsVerdict = cWorker.JobResultFromContent("0", blnAccessible)
+    TestAssert blnIsVerdict, "0 is a verdict"
+    TestAssert Not blnAccessible, "0 means the database is not accessible"
+
+    ' The worker writes the value on its own line, so a trailing newline is ordinary.
+    blnIsVerdict = cWorker.JobResultFromContent("1" & vbCrLf, blnAccessible)
+    TestAssert blnIsVerdict, "a trailing newline does not spoil the verdict"
+
+    blnIsVerdict = cWorker.JobResultFromContent("  0  ", blnAccessible)
+    TestAssert blnIsVerdict, "surrounding whitespace is trimmed"
+    TestAssert Not blnAccessible, "and the trimmed value is still the one read"
+
+End Sub
+
+
+Public Sub TestWorkerResultTreatsAnythingElseAsNoAnswerYet()
+
+    Dim cWorker As clsWorker
+    Dim blnAccessible As Boolean
+
+    Set cWorker = New clsWorker
+
+    ' This value must survive every call below: the caller retries, and a non-answer
+    ' that overwrote it would turn a slow read into a verdict nobody wrote.
+    blnAccessible = True
+
+    TestAssert Not cWorker.JobResultFromContent("", blnAccessible), _
+        "an empty file is not an answer"
+    TestAssert Not cWorker.JobResultFromContent("   ", blnAccessible), _
+        "a blank line is not an answer"
+    TestAssert Not cWorker.JobResultFromContent("10", blnAccessible), _
+        "10 is not one of the two values the worker writes"
+    TestAssert Not cWorker.JobResultFromContent("true", blnAccessible), _
+        "the worker never writes words"
+    TestAssert Not cWorker.JobResultFromContent(vbCrLf & "1", blnAccessible), _
+        "the value is read from the first line only"
+
+    TestAssert blnAccessible, "a non-answer leaves the caller value untouched"
+
+End Sub
+

--- a/Version Control.accda.src/modules/Tests/Infrastructure/modTestWorkerResult.bas
+++ b/Version Control.accda.src/modules/Tests/Infrastructure/modTestWorkerResult.bas
@@ -3,10 +3,8 @@
 ' Module    : modTestWorkerResult
 ' Author    : Ricardo Hernandez (Notarnet)
 ' Date      : 9/1/2026
-' Purpose   : Unit tests for the worker's file result channel: what counts as an answer
-'           : from the accessibility probe and what does not. The distinction matters
-'           : because a read can fail transiently, and answering "not accessible" to
-'           : that would be a false negative that is silent and intermittent.
+' Purpose   : Unit tests for the worker's file result channel: which tokens count as
+'           : a terminal answer (1, 0, U) and which leave the caller untouched.
 '---------------------------------------------------------------------------------------
 Option Compare Database
 Option Explicit
@@ -15,29 +13,38 @@ Option Private Module
 '@Tag("unit")
 
 
-Public Sub TestWorkerResultAcceptsOnlyTheTwoWrittenValues()
+Public Sub TestWorkerResultAcceptsWrittenTokens()
 
     Dim cWorker As clsWorker
-    Dim blnAccessible As Boolean
+    Dim varResult As Variant
     Dim blnIsVerdict As Boolean
 
     Set cWorker = New clsWorker
 
-    blnIsVerdict = cWorker.JobResultFromContent("1", blnAccessible)
+    blnIsVerdict = cWorker.JobResultFromContent("1", varResult)
     TestAssert blnIsVerdict, "1 is a verdict"
-    TestAssert blnAccessible, "1 means the database is accessible"
+    TestAssert varResult = True, "1 means the database is accessible"
 
-    blnIsVerdict = cWorker.JobResultFromContent("0", blnAccessible)
+    blnIsVerdict = cWorker.JobResultFromContent("0", varResult)
     TestAssert blnIsVerdict, "0 is a verdict"
-    TestAssert Not blnAccessible, "0 means the database is not accessible"
+    TestAssert varResult = False, "0 means the database is not accessible"
 
     ' The worker writes the value on its own line, so a trailing newline is ordinary.
-    blnIsVerdict = cWorker.JobResultFromContent("1" & vbCrLf, blnAccessible)
+    blnIsVerdict = cWorker.JobResultFromContent("1" & vbCrLf, varResult)
     TestAssert blnIsVerdict, "a trailing newline does not spoil the verdict"
+    TestAssert varResult = True, "newline still reads as accessible"
 
-    blnIsVerdict = cWorker.JobResultFromContent("  0  ", blnAccessible)
+    blnIsVerdict = cWorker.JobResultFromContent("  0  ", varResult)
     TestAssert blnIsVerdict, "surrounding whitespace is trimmed"
-    TestAssert Not blnAccessible, "and the trimmed value is still the one read"
+    TestAssert varResult = False, "and the trimmed value is still the one read"
+
+    blnIsVerdict = cWorker.JobResultFromContent("U", varResult)
+    TestAssert blnIsVerdict, "U is a published unknown"
+    TestAssert IsEmpty(varResult), "U leaves the transport result Empty"
+
+    blnIsVerdict = cWorker.JobResultFromContent("U" & vbCrLf, varResult)
+    TestAssert blnIsVerdict, "U with a trailing newline is still unknown"
+    TestAssert IsEmpty(varResult), "unknown survives the newline"
 
 End Sub
 
@@ -45,26 +52,47 @@ End Sub
 Public Sub TestWorkerResultTreatsAnythingElseAsNoAnswerYet()
 
     Dim cWorker As clsWorker
-    Dim blnAccessible As Boolean
+    Dim varResult As Variant
 
     Set cWorker = New clsWorker
 
     ' This value must survive every call below: the caller retries, and a non-answer
     ' that overwrote it would turn a slow read into a verdict nobody wrote.
-    blnAccessible = True
+    varResult = True
 
-    TestAssert Not cWorker.JobResultFromContent("", blnAccessible), _
+    TestAssert Not cWorker.JobResultFromContent("", varResult), _
         "an empty file is not an answer"
-    TestAssert Not cWorker.JobResultFromContent("   ", blnAccessible), _
+    TestAssert Not cWorker.JobResultFromContent("   ", varResult), _
         "a blank line is not an answer"
-    TestAssert Not cWorker.JobResultFromContent("10", blnAccessible), _
-        "10 is not one of the two values the worker writes"
-    TestAssert Not cWorker.JobResultFromContent("true", blnAccessible), _
+    TestAssert Not cWorker.JobResultFromContent("10", varResult), _
+        "10 is not one of the tokens the worker writes"
+    TestAssert Not cWorker.JobResultFromContent("true", varResult), _
         "the worker never writes words"
-    TestAssert Not cWorker.JobResultFromContent(vbCrLf & "1", blnAccessible), _
+    TestAssert Not cWorker.JobResultFromContent("unknown", varResult), _
+        "the word unknown is not the U token"
+    TestAssert Not cWorker.JobResultFromContent(vbCrLf & "1", varResult), _
         "the value is read from the first line only"
 
-    TestAssert blnAccessible, "a non-answer leaves the caller value untouched"
+    TestAssert varResult = True, "a non-answer leaves the caller value untouched"
 
 End Sub
 
+
+Public Sub TestAccessibilityFromProbeResultCollapsesUnknown()
+
+    Dim cWorker As clsWorker
+
+    Set cWorker = New clsWorker
+
+    TestAssert Not cWorker.AccessibilityFromProbeResult(Empty), _
+        "unknown is not accessible"
+    TestAssert cWorker.AccessibilityFromProbeResult(True), _
+        "True stays accessible"
+    TestAssert Not cWorker.AccessibilityFromProbeResult(False), _
+        "False stays inaccessible"
+
+    ' All three build callers go through DatabaseAccessibleToOtherClients, which
+    ' uses this collapse. Unknown therefore cannot reach the in-place merge path,
+    ' which requires a positive result before setting m_blnVerifiedAccessible.
+
+End Sub

--- a/Version Control.accda.src/modules/Tests/modTestAssert.bas
+++ b/Version Control.accda.src/modules/Tests/modTestAssert.bas
@@ -121,6 +121,7 @@ Public Function TestClassFactory(ByVal strClassName As String) As Object
         Case "clsTestSourceParser": Set TestClassFactory = New clsTestSourceParser
         Case "clsTestSqlFormatter": Set TestClassFactory = New clsTestSqlFormatter
         Case "clsTestSqlSyntax": Set TestClassFactory = New clsTestSqlSyntax
+        Case "clsTestWorkerLifecycle": Set TestClassFactory = New clsTestWorkerLifecycle
     End Select
 '--- END TEST CLASS ENTRIES ---
 End Function

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -307,12 +307,21 @@ A handful of jobs cannot run in the process that is running the add-in.
 `clsWorker` extracts the VBScript below its `' *** BEGIN WORKER SCRIPT ***` marker
 into `Worker.vbs` in the install folder and launches it with `wscript`. Anything
 added to the class **above** that marker stays VBA and is not part of the script.
-Results come back through `modAPI.WorkerCallback` → `Worker.ReturnWorker`.
+Most results come back through `modAPI.WorkerCallback` → `Worker.ReturnWorker`.
+`IsDatabaseAccessible` cannot take that path: it is exempt from attaching to
+Access (the bind fails for an `.accda` host, and attaching is otherwise only
+needed to speak). The worker writes a one-token file (`1` / `0` / `U`) to a
+per-job path reserved before launch; `WaitForQueue` polls that file every
+100 ms and returns as soon as a token appears. That wait is in-process and
+synchronous — it is not an agent timer and not another `rebuild-status.json`
+workflow. `Worker.IsDatabaseAccessible` preserves `Empty` for unknown;
+`modBuild.DatabaseAccessibleToOtherClients` is the policy boundary that
+collapses unknown to `False`.
 
 | Consumer | Why out of process |
 |---|---|
 | `Run_SaveVbaProject` (via `modVbeUtility.SaveCurrentVBProject`) | The VBE Save command saves nothing while the caller's own VBA is on the stack. No in-process substitute works — that procedure's header lists four that were tried. |
-| `IsDatabaseAccessible` | The engine does not report its lock state to same-process callers. |
+| `IsDatabaseAccessible` | The engine does not report its lock state to same-process callers. Result is file-delivered; see above. |
 | `Run_UninstallAddin` | Deletes the add-in file, which Access holds open until it exits. |
 | `Run_BuildAndInstall` (`VCS.RebuildAddIn`) | The add-in cannot rebuild and reinstall itself while loaded. `vcs_rebuild_addin` carries its HTTP callback identity through `Worker.vbs`, so the builder uses the normal `APIAsync` log/progress stream; `logs/rebuild-status.json` covers compile/install and recovery after Access exits. Refuses when another `MSACCESS.EXE` in the session has one of the files it replaces loaded as a VBA project, and never closes another process. See [agentic-rebuild.md](agentic-rebuild.md). |
 


### PR DESCRIPTION
`CheckDatabaseAccessible` is the one worker action whose only return path is the COM callback, and
that path is unavailable in exactly the situation the probe exists to measure. This gives it a
result channel of its own — a file — using the mechanism this project already operates for the
rebuild handoff.

`clsWorker.cls`, +210/−5, plus a new test module. No new dependencies: `CatchAny`,
`LogUnhandledErrors`, `VerifyPath`, `DeleteFile`, `ReadFile`, `UniqueHashSuffix`,
`modInstall.UseWorkerScript` and `T()` all already exist on `dev`.

## The problem, in the project's own words

Two docstrings on `dev` describe this exact failure, and one of them already fixes half of it:

- **`modBuild.bas:883-892`**, on `DatabaseAccessibleToOtherClients`: it says the answer should not
  be left to depend on a skipped worker job yielding an empty result. That is enunciated and then
  handled for **one** of the two ways of reaching that empty result — the toggle being off, where
  nothing is launched. The other way, a worker that launched and died, still behaves the way the
  docstring says it should not.
- **`modInstall.bas:2050-2056`**, on `WaitForRebuildHandoff`: `Shell()` reports that a process was
  created, not that the script survived its own startup, so a worker that dies immediately is
  otherwise indistinguishable from one still running. That was solved with a status file, and
  "proof of life" is the phrase used for it.

So this is not a new concern and not a new mechanism. It applies the second one to the other action
that needs it.

Concretely: `clsWorker.cls:620-629` is the only value-returning path in the worker, and it runs
inside `If Not objApp Is Nothing Then`. On `dev` the probe is **not** exempt from the attach — only
`BuildAndInstall` is (`clsWorker.cls:560`) — so it enters that block and tries `GetObject` like any
other action. When the file cannot be bound by any route, which is the window the probe is called
in, `objApp` is `Nothing` and the callback never runs. Making the probe skip the attach (so it does
not sit waiting on a `GetObject` that can take twenty seconds) is what obliges giving it a channel.

I checked `f53a237c` first, since its title looked like it might already cover this. It does not:
`callback_url` and `operation_id` are read only by the `BuildAndInstall` branch, and
`Case "CheckDatabaseAccessible"` still returns through the COM callback. That commit does say
rebuild-status.json is kept deliberately for durable recovery, which is the same reasoning applied
here.

## Decisions in here that are worth a look

1. **On a failed `FileExists`, nothing is written.** The guard lives inside the attach branch on
   `dev`, so exempting this action skips it; it is replicated in the `Case`. During a full build the
   database is renamed aside and for a moment the path does not resolve — that is not an answer.
   Writing `0` there would turn it into a definitive "not accessible" and cost the caller a reopen
   it does not need.
2. **The reader gives no verdict on anything unexpected.** Only `1` and `0` are answers. Anything
   else — including a `ReadFile` that fails — leaves the caller's value untouched and is retried on
   the next interval, because a read can fail transiently (an antivirus holding a just-published
   file is the ordinary case) and the job timeout already bounds the retries.
3. **The third-state warning is silent when the worker is off.** With `modInstall.UseWorkerScript`
   disabled (#727) nothing is queued and the caller reads empty by design, with documented
   fallbacks. A blind warning would fire on every build for anyone who has it off.

Writing uses `ADODB.Stream` with `SaveToFile strFile, 2`, matching `ReadFile`'s UTF-8. An earlier
version of this change wrote with `CreateTextFile`, which is ANSI, and worked only by accident of
the content being ASCII.

## Measured

- **The window this addresses still exists on `dev`.** Measured 2 Sep 2026 on a pristine `dev`
  build (`7521c7d9`), disposable DAO-created databases, 10 ms sampling: present in every build,
  15–62 ms idle (mean 32.6 ms), and it dilates under load — mean 71.5 ms, max 126 ms with 9
  competing threads. It does not scale with database size: at 540 tables the builds take six times
  longer and the window stays at 34.4 ms. **This is a lower bound, not the full non-bindability
  window**: the probe observes only that the file does not yet exist, not that the ROT entry is
  absent, because a faithful `GetObject` probe starts an `-Embedding` instance on every attempt and
  contaminates the run. So: the window exists and grows under load; I am deliberately not offering a
  magnitude comparison against anything.
- **The probe earns its place.** Across the 23 build logs on this workstation, 17 reopened in shared
  mode and 6 did not, so the probe saved the reopen roughly one build in four. That is the argument
  against the more radical alternative of deleting the probe instead of fixing it.
- **The exit code cannot be the channel.** With an uncaught error 424 and an execution control (a
  file the script creates before failing, so a fast exit is not mistaken for "nothing ran"),
  `cscript`, `cscript //B`, `wscript //B` and `wscript` all exit **0** and all ran. A dead worker
  and a correct one are indistinguishable there.

## Tests

The parse decision is extracted into `JobResultFromContent` so it can be exercised, and
`modTestWorkerResult.bas` covers it: 13 assertions over what counts as an answer and what leaves the
caller's value alone. Verified by mutation, not just by passing — accepting any non-empty value
instead of only `1`/`0` fails exactly three assertions (`"10"`, `"true"`, and the one checking the
caller's value survives a non-answer), and reverting returns to green.

Full suite on a build of this branch: 470 procedures, **2,253 assertions, 0 failures**, 5 empty, no
dialogs and no orphaned Access.

**What is not covered, and should be said:** the VBScript half has no automated test. What is
established about it is that the body is valid VBScript in 32- and 64-bit, not that its new branch
does what it says.

## One decision I would rather leave to you

The three callers of `DatabaseAccessibleToOtherClients` have different consequences:
`modBuild.bas:663` reopens in shared mode, `:985` changes the flush strategy after saving the VBA
project, and **`:1086` abandons the in-place merge entirely**, logging "Database is not accessible
to other clients" — which on `Empty` is an assertion of fact nobody measured.

This change collapses "unknown" to `False` with a global warning. That is conservative and matches
the `modBuild` docstring, but at `:1086` it is arguable: giving up a whole fast path because the
answer is unknown is not obviously right. If you would rather decide it per caller, the seam is
`DatabaseAccessibleToOtherClients` itself, where that policy already lives — not `clsWorker`. I did
not do it here because it would mean exposing a second output value, which is more surface, not
less.

Also known and left deliberately: if the job expires, `m_strResultFile` still points at a file the
worker may write late. A later `WaitForQueue` would read it and call `ReturnWorker` with a key no
longer queued, which produces one log line and nothing else. The next call overwrites both fields.

## Two things this is not

- **Not a `//B` proposal.** `wscript //B` suppresses the dialog for the whole worker body, including
  the `MsgBox` calls that remain on `dev`; this change covers one action. `//B` is a separate and
  earlier matter, and it should not be proposed by claiming it unblocks a hang — in the run above
  the no-`//B` case also finished on its own, in 9.4 s, leaving no residual process.
- **Not a fix for #722.** That issue's cause is dead on `dev` (`82a7096e` is an ancestor of HEAD).
  It is a precedent only: its reporter described the structural point — a worker that dies before it
  can call back leaves `WaitForQueue` to time out — and that is the point this addresses.
