### PR TITLE
fix(tabledef): stop the export from deleting a local table's metadata sidecar

### DIFF
--- a/Version Control.accda.src/modules/Components/clsDbTableDef.cls
+++ b/Version Control.accda.src/modules/Components/clsDbTableDef.cls
@@ -215,16 +215,19 @@ Private Sub IDbComponent_Export(Optional strAlternatePath As String)
     Dim strExportFolder As String
     strExportFolder = FSO.GetParentFolderName(strFile) & PathSep
 
+    ' Remove any alternate source file in case we have switched formats.
+    ' This runs BEFORE the metadata sidecar is written: a local table's alternate-format
+    ' name is <name>.json, which is also the sidecar's name, so removing it afterwards
+    ' would delete the metadata that was just exported.
+    If strAlternatePath = vbNullString Then
+        RemoveAlternateFormatSourceFile
+    End If
+
     ' Export object metadata for local tables into a companion .json file.
     ' Linked tables already have metadata included in their primary .json above.
     If Not IsLinkedTable Then
         ExportObjectMetadata strExportFolder & GetSafeFileName(m_Table.Name) & ".json", _
             "Tables", m_Table.Name, Me
-    End If
-
-    ' Remove any alternate source file in case we have switched formats
-    If strAlternatePath = vbNullString Then
-        RemoveAlternateFormatSourceFile
     End If
 
     ' Optionally save in SQL format

--- a/Version Control.accda.src/modules/Tests/Components/modTestTableDef.bas
+++ b/Version Control.accda.src/modules/Tests/Components/modTestTableDef.bas
@@ -17,6 +17,7 @@ Private Const TEST_TABLE_BIGINT As String = "vcs_test_bigint_repair"
 Private Const TEST_TABLE_OUTSIDE_EXPORT As String = "vcs_test_td_outside_export"
 Private Const TEST_TABLE_DECIMAL_SQL As String = "vcs_test_decimal_sql"
 Private Const TEST_TABLE_DECIMAL_DAO As String = "vcs_test_decimal_dao"
+Private Const TEST_TABLE_HIDDEN_SIDECAR As String = "vcs_test_hidden_sidecar"
 
 
 '---------------------------------------------------------------------------------------
@@ -543,6 +544,88 @@ Private Function DecimalFixtureXml() As String
 
 End Function
 
+
+'---------------------------------------------------------------------------------------
+' Procedure : TestHiddenLocalTableKeepsMetadataSidecar
+' Author    : Ricardo Hernandez
+' Date      : 9/5/2026
+' Purpose   : A hidden local table must keep its companion metadata file after a normal
+'           : export. The alternate-format name for a local table is <name>.json -- the
+'           : same name the metadata sidecar uses -- so RemoveAlternateFormatSourceFile
+'           : deletes the file ExportObjectMetadata wrote a few lines earlier, and the
+'           : hidden attribute never reaches source. A Build from Source then recreates
+'           : the table visible.
+'           :
+'           : The export folder is redirected to a temp folder so the fixture never
+'           : writes into the project's own source tree, and restored before the
+'           : assertions so a failure cannot leave the option pointing elsewhere.
+'---------------------------------------------------------------------------------------
+'
+Public Sub TestHiddenLocalTableKeepsMetadataSidecar()
+    '@Tag("integration")
+
+    Dim cTable As clsDbTableDef
+    Dim cComponent As IDbComponent
+    Dim dFile As Dictionary
+    Dim dItems As Dictionary
+    Dim strFolder As String
+    Dim strPriorFolder As String
+    Dim lngPriorFormat As Long
+    Dim strBase As String
+    Dim strXmlFile As String
+    Dim strJsonFile As String
+    Dim blnWasHidden As Boolean
+    Dim blnJsonExists As Boolean
+    Dim blnHasHidden As Boolean
+
+    DropTestTable TEST_TABLE_HIDDEN_SIDECAR
+
+    CurrentProject.Connection.Execute _
+        "CREATE TABLE [" & TEST_TABLE_HIDDEN_SIDECAR & "] ([ID] LONG)"
+    RefreshTableCollections CurrentDb
+    Application.SetHiddenAttribute acTable, TEST_TABLE_HIDDEN_SIDECAR, True
+    blnWasHidden = Application.GetHiddenAttribute(acTable, TEST_TABLE_HIDDEN_SIDECAR)
+
+    strFolder = GetTempFolder("vcs_hidden_sidecar")
+    strPriorFolder = Options.ExportFolder
+    lngPriorFormat = Options.ExportFormatVersion
+    Options.ExportFolder = AddSlash(strFolder)
+    Options.ExportFormatVersion = EFV_5_0_0
+
+    ' Export through the normal (non-alternate) path -- the one a real export takes for
+    ' any table the change scan did not already export to the temp folder.
+    Set cTable = New clsDbTableDef
+    Set cComponent = cTable
+    Set cComponent.DbObject = CurrentData.AllTables(TEST_TABLE_HIDDEN_SIDECAR)
+    cComponent.Export
+
+    strBase = Options.GetExportFolder & "tbldefs" & PathSep & GetSafeFileName(TEST_TABLE_HIDDEN_SIDECAR)
+    strXmlFile = strBase & ".xml"
+    strJsonFile = strBase & ".json"
+    blnJsonExists = FSO.FileExists(strJsonFile)
+    If blnJsonExists Then
+        Set dFile = ReadJsonFile(strJsonFile)
+        If Not dFile Is Nothing Then
+            If dFile.Exists("Items") Then
+                Set dItems = dFile("Items")
+                If dItems.Exists("Hidden") Then blnHasHidden = dItems("Hidden")
+            End If
+        End If
+    End If
+
+    ' Restore before asserting so a failure cannot leave the options redirected.
+    Options.ExportFolder = strPriorFolder
+    Options.ExportFormatVersion = lngPriorFormat
+
+    TestAssert blnWasHidden, "fixture table is hidden before the export"
+    TestAssert FSO.FileExists(strXmlFile), "local table schema was exported"
+    TestAssert blnJsonExists, "metadata sidecar survives the export of a hidden local table"
+    TestAssert blnHasHidden, "sidecar records the hidden attribute"
+
+    If FSO.FolderExists(strFolder) Then FSO.DeleteFolder strFolder, True
+    DropTestTable TEST_TABLE_HIDDEN_SIDECAR
+
+End Sub
 
 '---------------------------------------------------------------------------------------
 ' Procedure : DropTestTable


### PR DESCRIPTION
Fixes #771.

A local table exports its schema to `tbldefs\<name>.xml` and its document properties and
hidden attribute to a `tbldefs\<name>.json` sidecar. `RemoveAlternateFormatSourceFile`
resolves the *other* format's file name, which for a local table is `<name>.json` -- the
sidecar's own name -- so running it after `ExportObjectMetadata` deleted the metadata
that had just been written.

The metadata only reached source by accident: when the change scan had already exported
the object to the temp folder, `modExport` moves those files over and the delete never
runs. Any table taking the normal export path lost its Description, document properties
and hidden attribute, and a Build from Source recreated a hidden table visible.

Moving the removal ahead of the sidecar export fixes both directions. A table switching
from linked to local now has its stale linked-table `.json` cleared before the sidecar is
written, instead of having `Connect` merged in and then the whole file dropped.

### Tests

The suite had no coverage of the hidden attribute at all, which is how this could go
unnoticed. `modTestTableDef.TestHiddenLocalTableKeepsMetadataSidecar` exports a hidden
local table through the non-alternate path and asserts the companion `.json` is still
there and still records the attribute. The export folder is redirected to a temp folder
so the fixture never writes into the project's own source, and restored before the
assertions so a failure cannot leave the option pointing elsewhere.

Seen failing before the fix, on assertions 3 and 4 while 1 and 2 pass:

```
1 fixture table is hidden before the export ..................  PASS
2 local table schema was exported ...........................   PASS
3 metadata sidecar survives the export of a hidden local table  FAIL
4 sidecar records the hidden attribute ......................   FAIL
```

Passing after it, 4/4. Full suite on this branch: 474 subs, 2264 assertions, 0 failures,
5 empty. Access 16.0 32-bit.
