### PR TITLE
fix(import): recursively resolve FindSourceFile for new @Folder-neste…

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1041,6 +1041,88 @@ property read can precede unfinished teardown.
 - `docs/mcp-runvba.md`
 - `msaccess-vcs-mcp/src/msaccess_vcs_mcp/vba_worker_manager.py`
 - `msaccess-vcs-mcp/tests/test_vba_worker_manager.py`
+## 2026-08-24 — FindSourceFile's new recursive fallback measured at ~8-17ms on a 140-file tree; no mitigation needed
+
+**Trigger**: The recursive-scan fallback added to `FindSourceFile` (see the paired
+"ScanFolderMetadata" decision below) only runs when the existing flat-root check misses. Before
+accepting it, measured its actual cost against a real, representative tree rather than assuming
+it was fine.
+
+**Options explored**:
+- **Skip benchmarking, reason from the design alone**: rejected. The design intent (only the
+  fallback path pays any new cost; the common case is unchanged) is a reasonable argument but not
+  a substitute for a real measurement on a real tree.
+- **Add caching/memoization of scan results across calls**: not needed — see decision below.
+
+**Decision**: Timed `FindFileRecursive` against `Version Control.accda.src\modules\` (140 files
+across ~10 subfolders, this add-in's own real module tree) for a guaranteed-miss lookup, 5 runs:
+7.8-16.6ms (avg ~13ms). The flat, single-extension `FSO.FileExists` baseline it's compared
+against: 0.0-2.9ms (avg ~0.6ms). The new fallback only executes when the flat check has already
+failed — i.e., only for a brand-new object placed directly in its real, nested `'@Folder` path
+rather than the flat root, a one-time-per-object event during development, not a hot loop
+executed on every import/export. At ~13ms worst case, no mitigation (caching, bounding the scan,
+etc.) is warranted.
+
+**What this rules out**: Revisiting this specific performance question unless a much larger tree
+(order of magnitude more files) is reported as slow in practice — this measurement is the
+baseline to compare against if that ever comes up.
+
+**Addendum**: `FindSourceFile` has exactly one caller (`ImportObject`) and no cross-call caching,
+so the ~13ms cost is paid **once per file that misses the flat check**, not once per import
+operation — importing N new nested-folder objects via N separate `ImportObject`/`vcs_import_object`
+calls re-scans the same tree N times (e.g. ~260ms total for 20 files on this tree size). Still
+small enough in absolute terms not to need a fix, but this is a per-file, not a one-time, cost —
+worth knowing if a future bulk-import scenario on a much larger tree makes the linear scaling
+matter. If that happens, an operation-scoped cache of the `ScanFolderMetadata` result (keyed by
+`BaseFolder`, invalidated at the start of each new top-level operation) would be the natural fix.
+
+**Relevant files**: `modFileWinAPI.bas` (`FindFileRecursive`), `clsVersionControl.cls`
+(`FindSourceFile`).
+
+---
+
+## 2026-08-24 — FindSourceFile subfolder lookup reuses ScanFolderMetadata rather than a new recursive walk
+
+**Trigger**: `clsVersionControl.ImportObject`'s fallback for a brand-new object (one that doesn't
+yet exist live, so `CurrentProject.AllModules`/`AllForms`/etc. can't resolve it) is
+`FindSourceFile`, which only checks `cComponent.BaseFolder & strObjectName & <ext>` — the
+component type's flat base folder, with no subfolder search. Any new object placed directly at
+its correct `'@Folder`-nested path (rather than the flat root as a manual workaround) is reported
+"Source file not found," even though the file genuinely exists on disk.
+
+**Options explored**:
+- **A new hand-written recursive FSO walk inside `FindSourceFile`**: rejected. Would duplicate an
+  already-solved problem in this codebase and risks being slower than necessary — `Scripting.
+  FileSystemObject` recursion issues many separate COM calls per folder/file, one of the exact
+  costs `modFileWinAPI`'s Win32-based scanners were written to avoid (see `AGENTS.md`'s File
+  System Operations section).
+- **`VCSIndex.GetCachedAnnotation`**: rejected. Requires an existing index entry keyed by
+  filename — a genuinely brand-new object has never been indexed, so there is nothing to look
+  up. Confirmed by reading `GetCachedAnnotation`'s own implementation before ruling it out, not
+  assumed.
+- **`modFileWinAPI.ScanFolderMetadata(folder, blnRecursive:=True)`**: chosen. Already implements
+  a single efficient `FindFirstFileW`/`FindNextFileW` recursive walk of an entire folder tree,
+  returning a `Dictionary` keyed by full file path with `(date, size)` per entry. Already used
+  for exactly this "scan a whole category folder once, cheaply" need in
+  `clsVCSIndex.GetModifiedSourceFiles`. Reusing it keeps the fix idiomatic (one scanning
+  convention across the codebase, not two) and gives predictable performance: the existing flat
+  check stays the fast, zero-cost common-case path; only a genuine miss pays for one recursive
+  scan, not a per-candidate-extension multiplied cost.
+
+**Decision**: `FindSourceFile` keeps its existing flat-root check unchanged (so the common case —
+an object already at the flat root, or already resolved by the live-object lookup one level up —
+has zero behavior or performance change). Only when that flat check finds nothing does it fall
+back to one `ScanFolderMetadata(cComponent.BaseFolder, blnRecursive:=True)` call, then checks each
+returned key's file name (via `FSO.GetFileName`) against the same candidate-extension list already
+used for the flat check, returning the first match.
+
+**What this rules out**: Any future FindSourceFile-adjacent code introducing its own ad hoc
+recursive-scan logic — `ScanFolderMetadata` is now the established pattern for "search this whole
+category folder once" and should be reused, not reinvented, the same way `GetModifiedSourceFiles`
+already does.
+
+**Relevant files**: `clsVersionControl.cls` (`FindSourceFile`), `modFileWinAPI.bas`
+(`ScanFolderMetadata`, read-only reference), `modTestFolderPlacement.bas` (new test).
 
 ---
 

--- a/Version Control.accda.src/modules/API/clsVersionControl.cls
+++ b/Version Control.accda.src/modules/API/clsVersionControl.cls
@@ -1764,6 +1764,13 @@ Private Function FindSourceFile(cComponent As IDbComponent, strObjectName As Str
         End If
     Next varExt
 
+    ' Not found at the flat base-folder root -- the object may live under a
+    ' '@Folder-nested subfolder (e.g. a brand-new object created directly at
+    ' its real, nested location rather than the flat root, per issue tracked
+    ' upstream). Fall back to a single recursive scan of the whole category
+    ' folder rather than reporting "not found" prematurely.
+    FindSourceFile = modFileWinAPI.FindFileRecursive(strFolder, strObjectName, aExtensions)
+
 End Function
 
 

--- a/Version Control.accda.src/modules/Tests/Core/modTestFolderPlacement.bas
+++ b/Version Control.accda.src/modules/Tests/Core/modTestFolderPlacement.bas
@@ -306,6 +306,48 @@ Private Sub WriteMovedModuleFixture(strStaleFolder As String, strCorrectFolder A
 End Sub
 
 
+Public Sub TestFindFileRecursive_FindsFileInNestedSubfolder()
+    Dim strRoot As String
+    Dim strBase As String
+    Dim strNestedFolder As String
+    Dim strExpected As String
+    Dim strFound As String
+
+    strRoot = GetTempFolder("vcs_find_file_recursive") & PathSep
+    strBase = strRoot & "modules" & PathSep
+    strNestedFolder = strBase & "Builder" & PathSep & "Tests" & PathSep & "Units" & PathSep
+    VerifyPath strNestedFolder
+
+    strExpected = strNestedFolder & "modNewNestedObject.bas"
+    WriteFile BuildTestModuleSource("modNewNestedObject", "Builder.Tests.Units"), strExpected
+
+    strFound = FindFileRecursive(strBase, "modNewNestedObject", Array(".bas", ".cls"))
+
+    TestAssert strFound = strExpected, _
+        "found nested file at '" & strFound & "', expected '" & strExpected & "'"
+
+    DeleteFolderPlacementFixture strRoot
+End Sub
+
+
+Public Sub TestFindFileRecursive_ReturnsEmptyWhenNoMatchExists()
+    Dim strRoot As String
+    Dim strBase As String
+
+    strRoot = GetTempFolder("vcs_find_file_recursive") & PathSep
+    strBase = strRoot & "modules" & PathSep
+    VerifyPath strBase & "Core" & PathSep
+
+    ' A file exists in the tree, but under a different name -- must not match.
+    WriteFile BuildTestModuleSource("modUnrelated", "Core"), strBase & "Core" & PathSep & "modUnrelated.bas"
+
+    TestAssert Len(FindFileRecursive(strBase, "modDoesNotExist", Array(".bas", ".cls"))) = 0, _
+        "no match anywhere in the tree returns empty string"
+
+    DeleteFolderPlacementFixture strRoot
+End Sub
+
+
 '---------------------------------------------------------------------------------------
 ' Procedure : BuildTestModuleSource
 ' Author    : Adam Waller

--- a/Version Control.accda.src/modules/Utility/modFileWinAPI.bas
+++ b/Version Control.accda.src/modules/Utility/modFileWinAPI.bas
@@ -398,6 +398,42 @@ End Function
 
 
 '---------------------------------------------------------------------------------------
+' Procedure : FindFileRecursive
+' Author    : bclothier
+' Date      : 8/24/2026
+' Purpose   : Search an entire folder tree (via ScanFolderMetadata's single Win32 pass)
+'           : for a file named strBaseName, trying each extension in aExtensions in order.
+'           : Returns the full path of the first match found anywhere under strFolder, or
+'           : a zero-length string if none exists. Used as the subfolder-search fallback
+'           : when a flat, base-folder-only check has already failed to find the file.
+'---------------------------------------------------------------------------------------
+'
+Public Function FindFileRecursive(strFolder As String, strBaseName As String, aExtensions As Variant) As String
+
+    Dim dMeta As Dictionary
+    Dim varExt As Variant
+    Dim varKey As Variant
+    Dim strFileName As String
+
+    Set dMeta = ScanFolderMetadata(strFolder, True)
+
+    ' Preserve the caller's extension priority: check every file in the tree
+    ' against the first extension before moving on to the next, matching the
+    ' same precedence a flat, single-folder check would use.
+    For Each varExt In aExtensions
+        strFileName = strBaseName & CStr(varExt)
+        For Each varKey In dMeta.Keys
+            If StrComp(FSO.GetFileName(CStr(varKey)), strFileName, vbTextCompare) = 0 Then
+                FindFileRecursive = CStr(varKey)
+                Exit Function
+            End If
+        Next varKey
+    Next varExt
+
+End Function
+
+
+'---------------------------------------------------------------------------------------
 ' Procedure : ScanMetadataRecurse
 ' Author    : Adam Waller
 ' Date      : 6/9/2026


### PR DESCRIPTION
When creating a new file, they cannot originate in the subfolders; the workaround is to put them at root, then import, then export so they move to the subfolder. The fix enables the new addition to originate anywhere with minimal effort. 