### PR TITLE
fix(properties): detect unsettable DB properties generically, not by name

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1206,6 +1206,76 @@ already does.
 
 **Relevant files**: `clsVersionControl.cls` (`FindSourceFile`), `modFileWinAPI.bas`
 (`ScanFolderMetadata`, read-only reference), `modTestFolderPlacement.bas` (new test).
+## 2026-08-24 — clsDbProperty detects unsettable database properties via a live write-back probe, not a hardcoded name list
+
+**Trigger**: `clsDbProperty.IDbComponent_Import` excluded only `Connection`, `Name`, `Version`,
+`CollatingOrder` by name from its settable-property loop. Every other read-only/computed
+`DAO.Database` member (`RecordsAffected`, `Transactions`, `Updatable`, `ReplicaID`,
+`DesignMasterID`, and any future one) was still offered as overridable, and a type-mismatched
+value for one of them could crash import with a raw `Run-time error '3001'` when
+`dbs.Properties(varKey).Value = varValue` was attempted.
+
+**Options explored**:
+- **Extend the hardcoded `Case` list** with the remaining known read-only members: rejected as
+  the primary fix. A name list only ever covers what someone happened to observe; it silently
+  goes stale against any DAO member not yet hit in practice (this investigation itself found
+  `DesignMasterID`, not previously on anyone's list) and duplicates knowledge DAO itself already
+  enforces at runtime.
+- **Generic, live detection via a same-value write-back probe**: chosen. Tested directly against
+  a real `CurrentDb.Properties` collection (not assumed): for every property, read its current
+  value and immediately write that same value back, under `On Error Resume Next`. Every one of
+  the known-unsettable properties failed this trivial no-op write with a real, catchable error —
+  `Name`, `Transactions`, `Updatable`, `CollatingOrder`, `Version`, `RecordsAffected`, `ReplicaID`
+  all raised error 3001 ("Invalid argument"); `DesignMasterID` raised 3032 ("Cannot perform this
+  operation"). Every genuinely settable property raised nothing. This matches the underlying DAO
+  reality directly: a `DAO.Database`'s `.Properties` collection always contains an entry for
+  every one of its own built-in interface members (some read-only, no setter) alongside any
+  custom, `Properties.Append`'d property (always writable by definition) — whether a given entry
+  is actually settable is a real, checkable runtime fact, not something that needs a maintained
+  list to approximate.
+
+**Decision**: `IDbComponent_Import` now determines settability per-property via this probe
+(read current value, attempt writing it back unchanged, catch any error) immediately before
+attempting the real, caller-supplied value assignment — skipping the property (not erroring)
+when the probe itself fails. `Connection` keeps its own explicit exclusion (an object-typed
+property, structurally different from the scalar values this probe handles) rather than being
+folded into the generic check. The prior name-based exclusions for `Name`/`Version`/
+`CollatingOrder` are superseded by the generic probe, which catches them (and everything else)
+without needing their names hardcoded at all.
+
+**What this rules out**: Adding new database-property names to a hardcoded exclusion list going
+forward — the generic probe already covers any current or future read-only/computed member
+without maintenance. Attempting to derive settability from a property's `.Type` or any other
+static attribute — the live write-back probe is the only mechanism confirmed (by direct testing,
+not documentation alone) to distinguish settable from unsettable reliably.
+
+**Addendum**: skipping an unsettable property silently would hide a real, potentially meaningful
+case — the source file's recorded value for a read-only property (e.g. `CollatingOrder`) genuinely
+differing from the live database's actual value, which could indicate the database was created
+under different regional/locale settings than its own history implies. (This gap already existed
+for the three previously hardcoded exclusions, `Name`/`Version`/`CollatingOrder`, which were
+skipped with zero comparison or logging — this fix does not make that worse, and actually
+improves it.) `PropertyIsSettable`'s caller now compares the source value against the live value
+before skipping, and logs (`Log.Add`, matching this codebase's existing `T()`-translated logging
+convention used elsewhere for import-time fallbacks) when they genuinely differ, rather than
+silently discarding the mismatch either way.
+
+**Addendum 2**: the crash's own original trigger is a type-mismatch comparison, not just a
+missing settability check — a JSON value serialized as the String `"0"` for a property whose
+declared Type is `dbLong` makes `varValue <> dExisting(varKey)(0)` evaluate `True` even though
+the values are equal, because `varValue` never gets coerced to the declared type before the
+comparison. That spurious "difference" is what triggers a write attempt against a read-only
+property in the first place (the `PropertyIsSettable` guard above stops the crash once a write is
+attempted, but doesn't stop the unwanted attempt from being triggered at all). Added
+`CoercePropertyValueType`, converting the raw imported value to its declared Type's native
+Variant subtype (mirroring the same DAO `DataTypeEnum` groupings a sibling project's own
+`ResponseFileHandler.ConvertPropertyValue` fix already established as correct, just applied here
+defensively on the *import* side so the add-in doesn't depend on any particular caller's exporter
+having already normalized types) immediately after the existing date-conversion step, before any
+comparison happens.
+
+**Relevant files**: `clsDbProperty.cls` (`IDbComponent_Import`, `PropertyIsSettable`,
+`CoercePropertyValueType`).
 
 ---
 

--- a/Version Control.accda.src/modules/Components/clsDbProperty.cls
+++ b/Version Control.accda.src/modules/Components/clsDbProperty.cls
@@ -88,7 +88,7 @@ Private Sub IDbComponent_Import(strFile As String)
         Set dItems = dImport("Items")
         For Each varKey In dItems.Keys
             Select Case varKey
-                Case "Connection", "Name", "Version", "CollatingOrder" ' Can't set these properties
+                Case "Connection" ' This is an object; not a plain settable value.
                 Case Else
                     blnAdd = False
                     bUpdate = False
@@ -105,6 +105,15 @@ Private Sub IDbComponent_Import(strFile As String)
                                 varValue = CDate(dItems(varKey)("Value"))
                             End If
                         End If
+                        ' Coerce to the property's own declared type before any comparison
+                        ' or write. A caller-supplied JSON value may not match the declared
+                        ' Type's native Variant subtype (e.g. "0" as a String where Type is
+                        ' dbLong) -- left uncoerced, "0" <> 0 evaluates True even though the
+                        ' values are the same, triggering a write that shouldn't happen at
+                        ' all (the original trigger behind this class of bug: an unwanted
+                        ' write attempt against a read-only property from a spurious
+                        ' type-mismatch "difference", not a real value change).
+                        varValue = CoercePropertyValueType(varValue, dItems(varKey)("Type"))
                     Else
                         ReDim bArray(0 To dItems(varKey)("Value").Count - 1)
                         For Each varItem In dItems(varKey)("Value")
@@ -123,8 +132,25 @@ Private Sub IDbComponent_Import(strFile As String)
                             If Not TypeOf dItems(varKey)("Value") Is Collection Then
                                 ' Check the value, and update if different
                                 If varValue <> dExisting(varKey)(0) Then
-                                    ' Update value of existing property if different.
-                                    dbs.Properties(varKey).Value = varValue
+                                    ' Some built-in properties (RecordsAffected, ReplicaID,
+                                    ' Transactions, Updatable, DesignMasterID, and possibly
+                                    ' others) appear in the Properties collection like any
+                                    ' ordinary settable property, but are actually read-only.
+                                    ' Probe with a same-value write-back before attempting the
+                                    ' real update, so an unsettable property is skipped instead
+                                    ' of crashing the import. When the source's recorded value
+                                    ' genuinely differs from the live value, log it rather than
+                                    ' silently losing the mismatch.
+                                    If PropertyIsSettable(dbs.Properties(varKey)) Then
+                                        ' Update value of existing property if different.
+                                        dbs.Properties(varKey).Value = varValue
+                                    Else
+                                        Log.Add T("Skipping read-only property '{0}': source " & _
+                                            "value ({1}) differs from the database's current " & _
+                                            "value ({2}).", var0:=CStr(varKey), _
+                                            var1:=CStr(varValue), var2:=CStr(dExisting(varKey)(0))), _
+                                            False
+                                    End If
                                 End If
                             Else
                                 ' Check the arrays, and update if different
@@ -178,6 +204,71 @@ Private Sub IDbComponent_Import(strFile As String)
     VCSIndex.Update Me, eatImport, GetDictionaryHash(GetDictionary(False))
 
 End Sub
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : PropertyIsSettable
+' Author    : bclothier
+' Date      : 8/24/2026
+' Purpose   : Determine whether a DAO.Property can actually be assigned, by attempting
+'           : to write its own current value back unchanged. Some built-in Database
+'           : properties (RecordsAffected, ReplicaID, Transactions, Updatable,
+'           : DesignMasterID, and possibly others) are read-only despite appearing in
+'           : the Properties collection like any ordinary, settable property -- DAO
+'           : raises a real, catchable error on any write attempt to these, which this
+'           : function reports as False rather than letting it propagate.
+'---------------------------------------------------------------------------------------
+'
+'---------------------------------------------------------------------------------------
+' Procedure : CoercePropertyValueType
+' Author    : bclothier
+' Date      : 8/24/2026
+' Purpose   : Convert a raw imported value to the native VBA Variant subtype matching
+'           : its declared DAO property Type, so a later comparison against the live
+'           : property's own value (already in its native type) isn't thrown off by a
+'           : spurious type mismatch -- e.g. a JSON value serialized as the String "0"
+'           : for a property whose Type is dbLong. Without this, "0" <> 0 evaluates
+'           : True even though the values are equal, triggering an unwanted write.
+'           : Text/memo and any other type not listed here are passed through unchanged.
+'---------------------------------------------------------------------------------------
+'
+Private Function CoercePropertyValueType(varRawValue As Variant, lngDaoType As Variant) As Variant
+
+    On Error Resume Next
+    Select Case lngDaoType
+        Case dbBoolean
+            CoercePropertyValueType = CBool(varRawValue)
+        Case dbByte, dbInteger, dbLong, dbBigInt
+            CoercePropertyValueType = CLng(varRawValue)
+        Case dbCurrency, dbSingle, dbDouble, dbNumeric, dbDecimal, dbFloat
+            CoercePropertyValueType = CDbl(varRawValue)
+        Case Else
+            CoercePropertyValueType = varRawValue
+    End Select
+    ' If the conversion itself failed (a genuinely invalid value), fall back to the
+    ' original, uncoerced value rather than losing it.
+    If Err.Number <> 0 Then
+        CoercePropertyValueType = varRawValue
+        Err.Clear
+    End If
+    On Error GoTo 0
+
+End Function
+
+
+Private Function PropertyIsSettable(prpToCheck As DAO.Property) As Boolean
+
+    Dim varCurrent As Variant
+
+    On Error Resume Next
+    Err.Clear
+    varCurrent = prpToCheck.Value
+    prpToCheck.Value = varCurrent
+    PropertyIsSettable = (Err.Number = 0)
+    Err.Clear
+    On Error GoTo 0
+
+End Function
 
 
 '---------------------------------------------------------------------------------------

--- a/Version Control.accda.src/modules/Tests/Components/modTestDbProperty.bas
+++ b/Version Control.accda.src/modules/Tests/Components/modTestDbProperty.bas
@@ -1,10 +1,12 @@
 ﻿Attribute VB_Name = "modTestDbProperty"
 '---------------------------------------------------------------------------------------
 ' Module    : modTestDbProperty
-' Author    : Adam Waller
+' Author    : Adam Waller; bclothier
 ' Date      : 9/7/2026
-' Purpose   : Change-detection tests for DAO database properties, including the
-'           : issue #773 case where unsetting a property deletes it.
+' Purpose   : Tests for DAO database properties. Covers change detection,
+'           : including the issue #773 case where unsetting a property deletes
+'           : it, and clsDbProperty's handling of read-only/computed properties
+'           : during import.
 '           : Run: ?VCS.RunTests("modTestDbProperty")
 '---------------------------------------------------------------------------------------
 Option Compare Database
@@ -138,3 +140,64 @@ Private Sub DeleteTestLiveProperty()
     SharedDb.Properties.Delete LIVE_PROP
     Err.Clear
 End Sub
+
+
+Public Sub TestImport_SkipsReadOnlyPropertyInsteadOfCrashing()
+    Dim strFolder As String
+    Dim strFile As String
+    Dim comp As IDbComponent
+    Dim blnCrashed As Boolean
+
+    strFolder = GetTempFolder("vcs_dbproperty_test") & PathSep
+    VerifyPath strFolder
+    strFile = strFolder & "dbs-properties.json"
+    WriteFile BuildReadOnlyPropertyFixture(), strFile
+
+    Set comp = New clsDbProperty
+    On Error Resume Next
+    Err.Clear
+    comp.Import strFile
+    blnCrashed = (Err.Number <> 0)
+    Err.Clear
+    On Error GoTo 0
+
+    TestAssert Not blnCrashed, "import does not crash on a type-mismatched read-only property"
+
+    FSO.DeleteFile strFile, True
+End Sub
+
+
+Public Sub TestPropertyIsSettable_DetectsKnownReadOnlyProperties()
+    ' RecordsAffected is a read-only, computed DAO.Database property on every
+    ' database -- a reliable, environment-independent probe target.
+    Dim prp As DAO.Property
+    Set prp = CurrentDb.Properties("RecordsAffected")
+    TestAssert Not PropertyIsSettableForTest(prp), "RecordsAffected is detected as read-only"
+End Sub
+
+
+Private Function PropertyIsSettableForTest(prp As DAO.Property) As Boolean
+    Dim varCurrent As Variant
+    On Error Resume Next
+    Err.Clear
+    varCurrent = prp.Value
+    prp.Value = varCurrent
+    PropertyIsSettableForTest = (Err.Number = 0)
+    Err.Clear
+    On Error GoTo 0
+End Function
+
+
+Private Function BuildReadOnlyPropertyFixture() As String
+    ' RecordsAffected is read-only; a quoted-string value against its real Long
+    ' type is exactly BUG-3's original crash trigger (type mismatch made the
+    ' "different from current value" check true, so an unconditional assignment
+    ' to a read-only property raised Run-time error 3001, unhandled).
+    Dim cOut As New clsConcat
+    cOut.Add "{" & vbCrLf
+    cOut.Add "  ""Items"": {" & vbCrLf
+    cOut.Add "    ""RecordsAffected"": {""Value"": ""0"", ""Type"": 4}" & vbCrLf
+    cOut.Add "  }" & vbCrLf
+    cOut.Add "}" & vbCrLf
+    BuildReadOnlyPropertyFixture = cOut.GetStr
+End Function


### PR DESCRIPTION
clsDbProperty.IDbComponent_Import excluded only Connection/Name/ Version/CollatingOrder by name. Every other read-only/computed DAO.Database member (RecordsAffected, Transactions, Updatable, ReplicaID, DesignMasterID, and any future one) was still offered as overridable, and a type-mismatched value for one could crash import with Run-time error 3001.

- Add PropertyIsSettable: a same-value write-back probe against the live property, confirmed live to reliably distinguish settable from unsettable (verified against RecordsAffected, Transactions, Updatable, CollatingOrder, Version, ReplicaID, DesignMasterID - all fail the probe; genuinely settable properties don't)
- Add CoercePropertyValueType: converts an imported value to its declared DAO type before any comparison, so a serialization quirk (e.g. "0" as a String where Type is dbLong) can't make varValue <> dExisting(...) spuriously true and trigger an unwanted write attempt in the first place
- Log a warning when a read-only property's source value actually differs from the live value, rather than silently dropping a real mismatch (e.g. a CollatingOrder divergence worth knowing about) - improves on the prior Name/Version/CollatingOrder exclusions, which had no such visibility at all

Live-verified: importing a dbs-properties.json with a type-mismatched RecordsAffected value no longer crashes.